### PR TITLE
Set flash start address to definition of CMSIS CORE

### DIFF
--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -239,14 +239,14 @@ protected:
     int sendAck;                 //!< Send an acknowledge or not-acknowledge byte if != 0
 
 private:
-    State state;                 //!< The state of the lib's telegram sending/receiving
+    volatile State state;                 //!< The state of the lib's telegram sending/receiving
     int sendTries;               //!< The number of repeats when sending a telegram
     int sendTriesMax;            //!< The maximum number of repeats when sending a telegram. Default: 3
     int nextByteIndex;           //!< The number of the next byte in the telegram
 
     int currentByte;             //!< The current byte that is received/sent, including the parity bit
     int sendTelegramLen;         //!< The size of the to be sent telegram in bytes (including the checksum).
-    byte *sendCurTelegram;       //!< The telegram that is currently being sent.
+    volatile byte *sendCurTelegram;       //!< The telegram that is currently being sent.
     byte *sendNextTel;           //!< The telegram to be sent after sbSendTelegram is done.
     int bitMask;
     int bitTime;                 // The bit-time within a byte when receiving

--- a/sblib/inc/sblib/platform.h
+++ b/sblib/inc/sblib/platform.h
@@ -56,7 +56,9 @@ unsigned int* ioconPointer(int port, int pinNum);
   extern unsigned char FLASH[];
 # define __vectors_start__ *FLASH
 #else
-  extern const unsigned int __vectors_start__;
+#if not defined LPC_FLASH_BASE
+  #define LPC_FLASH_BASE 0
+#endif
 #endif
 
 /**

--- a/sblib/inc/sblib/platform.h
+++ b/sblib/inc/sblib/platform.h
@@ -62,8 +62,7 @@ unsigned int* ioconPointer(int port, int pinNum);
 /**
  * The base address of the flash.
  */
-#define FLASH_BASE_ADDRESS ((unsigned char*) &__vectors_start__)
-
+# define FLASH_BASE_ADDRESS ((unsigned char *)LPC_FLASH_BASE)
 /**
 * The size of a flash sector in bytes.
 */

--- a/sblib/inc/sblib/platform.h
+++ b/sblib/inc/sblib/platform.h
@@ -54,11 +54,11 @@ unsigned int* ioconPointer(int port, int pinNum);
 
 #ifdef IAP_EMULATION
   extern unsigned char FLASH[];
-# define __vectors_start__ *FLASH
+  #define LPC _Flash_Base *FLASH
 #else
-#if not defined LPC_FLASH_BASE
-  #define LPC_FLASH_BASE 0
-#endif
+  #if not defined LPC_FLASH_BASE
+    #define LPC_FLASH_BASE 0
+  #endif
 #endif
 
 /**


### PR DESCRIPTION
The original definition of FLASH_BASE_ADDRESS relies on the assumption that flash start is equal to vector start. This does not work with applications that use the boot loader / updater.