### PR TITLE
changes at MemMapper (byte order of getUIntX and setUIntX)

### DIFF
--- a/sblib/inc/sblib/mem_mapper.h
+++ b/sblib/inc/sblib/mem_mapper.h
@@ -13,6 +13,8 @@
 #ifndef SBLIB_MEM_MAPPER_H_
 #define SBLIB_MEM_MAPPER_H_
 
+#include <sblib/platform.h>
+
 #define MEM_MAPPER_SUCCESS         0
 #define MEM_MAPPER_INVALID_ADDRESS -1
 #define MEM_MAPPER_NOT_MAPPED      -2

--- a/sblib/src/mem_mapper.cpp
+++ b/sblib/src/mem_mapper.cpp
@@ -282,12 +282,12 @@ unsigned int MemMapper::getUIntX(int virtAddress, int length)
 	for(int i = 0; i < length; i++)
 	{
 		byte b;
-		if(endianess == LITTLE_ENDIAN)
-			address = virtAddress + length - i - 1;
-		else
+		if(endianess == BIG_ENDIAN)
 			address = virtAddress + i;
+		else
+			address = virtAddress + length - i - 1;
 		readMem( address , b);
-        ret <<= 8;
+		ret <<= 8;
 		ret |= (unsigned int)b;
 	}
     return ret;
@@ -300,7 +300,7 @@ unsigned short MemMapper::getUInt16(int virtAddress)
 
 unsigned int MemMapper::getUInt32(int virtAddress)
 {
-	return (unsigned short)getUIntX(virtAddress, 4);
+	return (unsigned int)getUIntX(virtAddress, 4);
 }
 
 int MemMapper::setUInt8(int virtAddress, byte data)


### PR DESCRIPTION
in Thread http://selfbus.forums3.com/post2721.html#p2721 I described the incompatibility of "getUIntX" and "setUIntX" (the Byte order was not the same for writing and reading)
additinal it was neccessary for me to add a header in mem_mapper.h (otherwise the define FLASH_PAGE_SIZE could not be found)