### PR TITLE
MemMapper.isMapped() nun auch als virtual deklariert.

### DIFF
--- a/sblib/inc/sblib/mem_mapper.h
+++ b/sblib/inc/sblib/mem_mapper.h
@@ -176,7 +176,7 @@ public:
      * @param virtAddresss - the virtual address of the data block.
      * @return true if virtual address is mapped
      */
-    bool isMapped(int virtAddress);
+    virtual bool isMapped(int virtAddress);
 
 private:
     int allocatePage(int virtPage);


### PR DESCRIPTION
Wurde bisher übersehen (und hat beim out-cs-bim112 jetzt zu Fehlern geführt).