### PR TITLE
fixed issue #24 delay(unsigned int msec) will result in a infinite

### DIFF
--- a/sblib/inc/sblib/platform.h
+++ b/sblib/inc/sblib/platform.h
@@ -15,7 +15,7 @@
 /**
  * Low level table of the IO ports
  */
-extern LPC_GPIO_TypeDef (* const gpioPorts[4]);
+extern LPC_GPIO_TypeDef* const gpioPorts[4];
 
 #elif defined(__LPC11UXX__)
 #include <LPC11Uxx.h>

--- a/sblib/src/timer.cpp
+++ b/sblib/src/timer.cpp
@@ -24,17 +24,25 @@ void delay(unsigned int msec)
 {
     unsigned int lastSystemTime = systemTime;
 
-    while (msec)
+    if (__get_IPSR() == 0x0) // check that no interrupt is active, otherwise "while" will end in a infinite loop
     {
-        if (lastSystemTime == systemTime)
+        while (msec)
         {
-            __WFI();
+            if (lastSystemTime == systemTime)
+            {
+                __WFI();
+            }
+            else
+            {
+                lastSystemTime = systemTime;
+                --msec;
+            }
         }
-        else
-        {
-            lastSystemTime = systemTime;
-            --msec;
-        }
+    }
+    else
+    {
+        // fall-back to waiting SysTick's
+        delayMicroseconds(msec);
     }
 }
 


### PR DESCRIPTION
 loop, in case it's called inside a interrupt service routine