### PR TITLE
closes #29 fatalError() now blinks by default PIN_PROG

### DIFF
--- a/sblib/inc/sblib/eib/bcu_base.h
+++ b/sblib/inc/sblib/eib/bcu_base.h
@@ -85,6 +85,7 @@ public:
      */
     void setProgPin(int prgPin) {
         progPin=prgPin;
+        setFatalErrorPin(progPin);
     }
     /**
      * Set ProgPin output inverted, must be called before begin method

--- a/sblib/inc/sblib/utils.h
+++ b/sblib/inc/sblib/utils.h
@@ -24,9 +24,15 @@ void reverseCopy(byte* dest, const byte* src, int len);
 
 /**
  * Call when a fatal application error happens. This function will never
- * return and the program LED will blink rapidly to indicate the error.
+ * return and the program LED (can be changed with setFatalErrorPin) will blink rapidly to indicate the error.
  */
 void fatalError();
+
+/**
+ * Set the Pin for fatalError()
+ * @param newPin - the new Pin
+ */
+void setFatalErrorPin(int newPin);
 
 /**
  * Get the offset of a field in a class, structure or type.

--- a/sblib/src/eib/bcu_base.cpp
+++ b/sblib/src/eib/bcu_base.cpp
@@ -32,6 +32,7 @@ BcuBase::BcuBase()
 :progButtonDebouncer()
 {
     progPin = PIN_PROG;
+    setFatalErrorPin(progPin);
     progPinInv = true;
     enabled = false;
 }

--- a/sblib/src/utils.cpp
+++ b/sblib/src/utils.cpp
@@ -12,7 +12,9 @@
 
 #include <sblib/digital_pin.h>
 #include <sblib/platform.h>
+#include <sblib/io_pin_names.h>
 
+static int fatalErrorPin = PIN_PROG;
 
 void reverseCopy(byte* dest, const byte* src, int len)
 {
@@ -28,12 +30,17 @@ void fatalError()
 {
     // We use only low level functions here as a fatalError() could happen
     // anywhere in the lib and we want to ensure that the function works
-    pinMode(PIO0_7, OUTPUT);
+    pinMode(fatalErrorPin, OUTPUT);
     SysTick_Config(0x1000000);
 
     while (1)
     {
         // Blink the LED on the LPCxpresso board
-        digitalWrite(PIO0_7, (SysTick->VAL & 0x800000) == 0 ? 1 : 0);
+        digitalWrite(fatalErrorPin, (SysTick->VAL & 0x200000) == 0 ? 1 : 0);
     }
+}
+
+void setFatalErrorPin(int newPin)
+{
+    fatalErrorPin = newPin;
 }


### PR DESCRIPTION
BcuBase.setProgPin also changes fatalErrorPin which can be set by setFatalErrorPin