### PR TITLE
closes #31 sblib now overrides the default HardFault exception handler

### DIFF
--- a/sblib/inc/sblib/utils.h
+++ b/sblib/inc/sblib/utils.h
@@ -24,7 +24,7 @@ void reverseCopy(byte* dest, const byte* src, int len);
 
 /**
  * Call when a fatal application error happens. This function will never
- * return and the program LED (can be changed with setFatalErrorPin) will blink rapidly to indicate the error.
+ * return and the program/fatalError LED (can be changed with setFatalErrorPin) will blink rapidly to indicate the error.
  */
 void fatalError();
 
@@ -109,5 +109,12 @@ void setFatalErrorPin(int newPin);
  * @brief Example:  CPP_QUOTE_EXPAND(BCU_NAME) results in "BCU2"  (if BCU_NAME is defined as BCU2)
  */
 #define CPP_QUOTE_EXPAND(str) CPP_QUOTE(str)
+
+/**
+ * Interrupt service routine to override the default HardFault exception handler in cr_startup_lpc11xx.cpp
+ * This function will never return and the program/fatalError LED
+ * will blink rapidly to indicate the error.
+ */
+extern "C" void HardFault_Handler();
 
 #endif /*sblib_utils_h*/

--- a/sblib/src/utils.cpp
+++ b/sblib/src/utils.cpp
@@ -35,11 +35,24 @@ void fatalError()
 
     while (1)
     {
-        // Blink the LED on the LPCxpresso board
-        digitalWrite(fatalErrorPin, (SysTick->VAL & 0x200000) == 0 ? 1 : 0);
+        // Blink the fatalErrorLED
+        digitalWrite(fatalErrorPin, (SysTick->VAL & 0x400000) == 0 ? 1 : 0);
     }
 }
 
+void HardFault_Handler()
+{
+    // We use only low level functions here as a HardFault could happen
+    // anywhere and we want to ensure that the function works
+    pinMode(fatalErrorPin, OUTPUT);
+    SysTick_Config(0x1000000);
+
+    while (1)
+    {
+        // Blink the fatalErrorLED
+        digitalWrite(fatalErrorPin, (SysTick->VAL & 0x200000) == 0 ? 1 : 0);
+    }
+}
 void setFatalErrorPin(int newPin)
 {
     fatalErrorPin = newPin;


### PR DESCRIPTION
from cr_startup_lpc11xx.cpp to rapidly blink the program/fatalError-LED