### PR TITLE
Fix out-of-bounds memory access in SYSTEMB

### DIFF
--- a/sblib/inc/sblib/eib/com_objects.h
+++ b/sblib/inc/sblib/eib/com_objects.h
@@ -357,7 +357,6 @@ protected:
 	 */
 	void sendGroupWriteTelegram(int objno, int addr, bool isResponse);
 	void processGroupWriteTelegram(int objno, byte* tel);
-	virtual const byte* getObjectTypeSizes() = 0;
 
     BcuBase* bcu;
     int le_ptr;

--- a/sblib/inc/sblib/eib/com_objectsBCU1.h
+++ b/sblib/inc/sblib/eib/com_objectsBCU1.h
@@ -57,11 +57,9 @@ public:
 	virtual byte* objectFlagsTable() override;
 
 	const ComConfigBCU1* objectConfigBCU1(int objno); ///\todo make protected again after ramLocation fix, see setup.cpp fixRamLoc(.) of 4sense-bcu1
-protected:
+private:
 	// The size of the object types BIT_7...VARDATA in bytes
 	const byte objectTypeSizes[10] = { 1, 1, 2, 3, 4, 6, 8, 10, 14, 14 };
-
-	virtual const byte* getObjectTypeSizes() override;
 };
 
 #endif /*sblib_com_objects_BCU1_h*/

--- a/sblib/inc/sblib/eib/com_objectsBCU1.h
+++ b/sblib/inc/sblib/eib/com_objectsBCU1.h
@@ -57,9 +57,6 @@ public:
 	virtual byte* objectFlagsTable() override;
 
 	const ComConfigBCU1* objectConfigBCU1(int objno); ///\todo make protected again after ramLocation fix, see setup.cpp fixRamLoc(.) of 4sense-bcu1
-private:
-	// The size of the object types BIT_7...VARDATA in bytes
-	const byte objectTypeSizes[10] = { 1, 1, 2, 3, 4, 6, 8, 10, 14, 14 };
 };
 
 #endif /*sblib_com_objects_BCU1_h*/

--- a/sblib/inc/sblib/eib/com_objectsSYSTEMB.h
+++ b/sblib/inc/sblib/eib/com_objectsSYSTEMB.h
@@ -44,11 +44,6 @@ public:
 
 	virtual inline const ComConfig& objectConfig(int objno) override;
 
-private:
-	// The size of the object types 6...20 in bytes
-	// KNX spec v2.1 3/5/1 p. 178 (section 4.12.5.2.4.1.4)
-	const byte objectTypeSizes[15] = { 1, 1, 2, 3, 4, 6, 8, 10, 14, 5, 7, 9, 11, 12, 13 };
-
 protected:
 	virtual int objectSize(int objno) override;
 	virtual byte* objectValuePtr(int objno) override;

--- a/sblib/inc/sblib/eib/com_objectsSYSTEMB.h
+++ b/sblib/inc/sblib/eib/com_objectsSYSTEMB.h
@@ -44,12 +44,12 @@ public:
 
 	virtual inline const ComConfig& objectConfig(int objno) override;
 
+private:
+	// The size of the object types 6...20 in bytes
+	// KNX spec v2.1 3/5/1 p. 178 (section 4.12.5.2.4.1.4)
+	const byte objectTypeSizes[15] = { 1, 1, 2, 3, 4, 6, 8, 10, 14, 5, 7, 9, 11, 12, 13 };
+
 protected:
-	// The size of the object types BIT_7...VARDATA in bytes
-	const byte objectTypeSizes[15] = { 1, 1, 2, 3, 4, 6, 8, 10, 14, 5, 7, 9, 11, 12, 13};
-
-	virtual const byte* getObjectTypeSizes() override;
-
 	virtual int objectSize(int objno) override;
 	virtual byte* objectValuePtr(int objno) override;
 	virtual void processGroupTelegram(uint16_t addr, int apci, byte* tel, int trg_objno) override;

--- a/sblib/src/eib/com_objects.cpp
+++ b/sblib/src/eib/com_objects.cpp
@@ -220,7 +220,7 @@ int ComObjects::telegramObjectSize(int objno)
 {
     int type = objectType(objno);
     if (type < BIT_7) return 0;
-    return getObjectTypeSizes()[type - BIT_7];
+    return objectSize(objno);
 }
 
 void ComObjects::addObjectFlags(int objno, int flags)
@@ -298,7 +298,7 @@ void ComObjects::_objectWrite(int objno, unsigned int value, int flags)
     }
     int sz = objectSize(objno);
 
-    if ((ptr == 0) || (sz == 0xff)) ///\todo check maximum possible objectSize sz = objectTypeSizes[10] = 15? 0xff can indicate a corrupted Ram/EEPROM
+    if ((ptr == 0) || (sz == -1))
         return;
 
     for (; sz > 0; --sz)

--- a/sblib/src/eib/com_objectsBCU1.cpp
+++ b/sblib/src/eib/com_objectsBCU1.cpp
@@ -17,8 +17,11 @@
 int ComObjectsBCU1::objectSize(int objno)
 {
     int type = objectType(objno);
-    if (type < BIT_7) return 1;
-    return objectTypeSizes[type - BIT_7];
+    if (type < BIT_7)
+        return 1;
+    if (type <= VARDATA)
+        return objectTypeSizes[type - BIT_7];
+    return -1;
 }
 
 byte* ComObjectsBCU1::objectValuePtr(int objno)
@@ -157,11 +160,6 @@ byte* ComObjectsBCU1::objectFlagsTable() // stored in RAM
     objCfgTablePtr++; // add 1 to get the RAM-Flags-Table Pointer
     return ((BcuDefault*)bcu)->userMemoryPtr(*objCfgTablePtr);
     //return (byte*)(((BcuDefault*)bcu)->userRam->userRamData + ((BcuDefault*)bcu)->userEeprom->userEepromData[((BcuDefault*)bcu)->userEeprom->commsTabPtr() + 1]);
-}
-
-inline const byte* ComObjectsBCU1::getObjectTypeSizes()
-{
-	return objectTypeSizes;
 }
 
 inline const ComConfig& ComObjectsBCU1::objectConfig(int objno) { return objectConfigBCU1(objno)->baseConfig; }

--- a/sblib/src/eib/com_objectsBCU1.cpp
+++ b/sblib/src/eib/com_objectsBCU1.cpp
@@ -16,6 +16,9 @@
 
 int ComObjectsBCU1::objectSize(int objno)
 {
+    // The size of the object types BIT_7...VARDATA in bytes
+    const byte objectTypeSizes[10] = { 1, 1, 2, 3, 4, 6, 8, 10, 14, 14 };
+
     int type = objectType(objno);
     if (type < BIT_7)
         return 1;

--- a/sblib/src/eib/com_objectsSYSTEMB.cpp
+++ b/sblib/src/eib/com_objectsSYSTEMB.cpp
@@ -13,8 +13,10 @@
 
 int ComObjectsSYSTEMB::objectSize(int objno)
 {
+    // KNX spec v2.1 3/5/1 p. 178 (section 4.12.5.2.4.1.4)
     int type = objectType(objno);
-    if (type < BIT_7) return 1;
+    if (type < BIT_7)
+        return 1;
     if (type < 21)
         return objectTypeSizes[type - BIT_7];
     if (type < 255)
@@ -104,11 +106,6 @@ byte* ComObjectsSYSTEMB::objectFlagsTable()
     	return ((BcuDefault*)bcu)->userMemoryPtr(makeWord(configTable[2], configTable[1]));
 
     return ((BcuDefault*)bcu)->userMemoryPtr(makeWord(configTable[1], configTable[2]));
-}
-
-inline const byte* ComObjectsSYSTEMB::getObjectTypeSizes()
-{
-	return objectTypeSizes;
 }
 
 inline const ComConfig& ComObjectsSYSTEMB::objectConfig(int objno)

--- a/sblib/src/eib/com_objectsSYSTEMB.cpp
+++ b/sblib/src/eib/com_objectsSYSTEMB.cpp
@@ -14,6 +14,9 @@
 int ComObjectsSYSTEMB::objectSize(int objno)
 {
     // KNX spec v2.1 3/5/1 p. 178 (section 4.12.5.2.4.1.4)
+    // The size of the object types 6...20 in bytes
+    const byte objectTypeSizes[15] = { 1, 1, 2, 3, 4, 6, 8, 10, 14, 5, 7, 9, 11, 12, 13 };
+
     int type = objectType(objno);
     if (type < BIT_7)
         return 1;


### PR DESCRIPTION
Add KNX spec reference comments. Turns out that for any object type >20, `ComObjects::telegramObjectSize()` accessed out-of-bounds memory.

Fix:
1. Do not expose the `objectTypeSizes` array via `getObjectTypeSizes()` anymore to prevent out-of-bounds accesses
2. Use result of `objectSize()` function as telegram object size instead
3. Ensure that no out-of-bounds access can happen in `ComObjectsBCU1::objectSize`
4. That also solves the TODO in `ComObjects::_objectWrite`