### PR TITLE
Fix incorrect pointer dereference

### DIFF
--- a/Bus-Updater/src/decompressor.cpp
+++ b/Bus-Updater/src/decompressor.cpp
@@ -106,7 +106,7 @@ int Decompressor::pageCompletedDoFlash()
 		// proceed to flash the decompressed page stored in the scratchpad RAM
 		d1("Diff - Program Page at Address 0x");
 		d2((unsigned int)startAddrOfPageToBeFlashed, HEX,4);
-		lastError = executeProgramFlash(*startAddrOfPageToBeFlashed, scratchpad, FLASH_PAGE_SIZE);
+		lastError = executeProgramFlash((unsigned int)startAddrOfPageToBeFlashed, scratchpad, FLASH_PAGE_SIZE);
 		//lastError = iapProgram(startAddrOfPageToBeFlashed, scratchpad, FLASH_PAGE_SIZE);
 		//lastError = UDP_IAP_SUCCESS; // Dry RUN! for debug
 	}


### PR DESCRIPTION
Found in my type safety endeavors (will request to merge that in another bigger PR):

`startAddrOfPageToBeFlashed` is an address and `executeProgramFlash` expects an address, so there's no need to dereference the field.

Please note that this is one likely reason why differential mode didn't work, but I did not run a test of the feature with this fix applied, so there may very well be other open issues.