### PR TITLE
Use pointers for memory addresses

### DIFF
--- a/Bus-Updater/inc/boot_descriptor_block.h
+++ b/Bus-Updater/inc/boot_descriptor_block.h
@@ -47,7 +47,7 @@
 #define BOOT_BLOCK_COUNT 1                      //!< Number of applications supported (application description blocks)
                                                 //!< @warning @ref BOOT_BLOCK_COUNT other's than 1 are not tested!
 
-extern unsigned char bl_id_string[BL_ID_STRING_LENGTH]; //!< default bootloader identity "string" used in @ref getAppVersion()
+extern char bl_id_string[BL_ID_STRING_LENGTH]; //!< default bootloader identity "string" used in @ref getAppVersion()
 
 /**
  * @struct AppDescriptionBlock
@@ -56,10 +56,10 @@ extern unsigned char bl_id_string[BL_ID_STRING_LENGTH]; //!< default bootloader 
  */
 typedef struct AppDescriptionBlock
 {
-    unsigned int startAddress;          ///< start address of the application
-    unsigned int endAddress;            ///< end address of the application
-    unsigned int crc;                   //!< crc from startAddress to end endAddress
-    unsigned int appVersionAddress;     //!< address of the APP_VERSION[20] @note string MUST start with "!AVP!@:" e.g. "!AVP!@:SBuid   1.00"
+    uint8_t * startAddress;         ///< start address of the application
+    uint8_t * endAddress;           ///< end address of the application
+    uint32_t crc;                   //!< crc from startAddress to end endAddress
+    char * appVersionAddress;       //!< address of the APP_VERSION[20] @note string MUST start with "!AVP!@:" e.g. "!AVP!@:SBuid   1.00"
 }__attribute__ ((aligned (BOOT_BLOCK_DESC_SIZE))) AppDescriptionBlock;
 
 /**
@@ -78,7 +78,7 @@ unsigned int checkApplication(AppDescriptionBlock * block);
  * @return      if valid, pointer to buffer of application version string (length BL_ID_STRING_LENGTH)
  *              otherwise bl_id_string
  */
-unsigned char * getAppVersion(AppDescriptionBlock * block);
+char * getAppVersion(AppDescriptionBlock * block);
 
 /**
  * @brief Return start address of application
@@ -87,21 +87,21 @@ unsigned char * getAppVersion(AppDescriptionBlock * block);
  * @return      Start address of application in case of valid descriptor block,
  *              otherwise base address of firmware area, directly behind bootloader
  */
-unsigned char * getFirmwareStartAddress(AppDescriptionBlock * block);
+uint8_t * getFirmwareStartAddress(AppDescriptionBlock * block);
 
 /**
  * @brief returns the first address of the bootloader image (_image_start symbol included by the linker)
  *
  * @return first address of the bootloader image
  */
-unsigned int bootLoaderFirstAddress(void);
+uint8_t * bootLoaderFirstAddress(void);
 
 /**
  * @brief returns the last address of the bootloader image (__image_end symbol included by the linker)
  *
  * @return last address of the bootloader image
  */
-unsigned int bootLoaderLastAddress(void);
+uint8_t * bootLoaderLastAddress(void);
 
 /**
  * @brief returns the size of the bootloader image in bytes (__image_end - _image_start - 1)
@@ -115,14 +115,14 @@ unsigned int bootLoaderSize(void);
  *
  * @return first address of the the default flash memory
  */
-unsigned int flashFirstAddress(void);
+uint8_t * flashFirstAddress(void);
 
 /**
  * @brief returns the last address of the default flash memory (__top_Flash symbol included by the linker)
  *
  * @return last address of the the default flash memory
  */
-unsigned int flashLastAddress(void);
+uint8_t * flashLastAddress(void);
 
 /**
  * @brief returns the size of the default flash memory in bytes (__top_Flash - __base_Flash - 1)
@@ -136,14 +136,14 @@ unsigned int flashSize(void);
  *
  * @return first address of the application's firmware
  */
-unsigned int applicationFirstAddress(void);
+uint8_t * applicationFirstAddress(void);
 
 /**
  * @brief returns the first address of the boot descriptor block
  *
  * @return first address of the boot descriptor block
  */
-unsigned int bootDescriptorBlockAddress(void);
+uint8_t * bootDescriptorBlockAddress(void);
 
 /**
  * @brief returns the page number of the boot descriptor block

--- a/Bus-Updater/inc/decompressor.h
+++ b/Bus-Updater/inc/decompressor.h
@@ -81,7 +81,7 @@ class Decompressor
 
 		uint32_t getCrc32();
 
-		uint32_t getStartAddrOfPageToBeFlashed();
+		uint8_t * getStartAddrOfPageToBeFlashed();
 
 		uint32_t getBytesCountToBeFlashed();
 

--- a/Bus-Updater/inc/dump.h
+++ b/Bus-Updater/inc/dump.h
@@ -37,10 +37,12 @@
 #   define d1(x) {serial.print(x);}
 #   define dline(x) {serial.println(x);}
 #   define d2(u,v,w) {serial.print(u,v,w);}
+#   define d2ptr(u) {serial.print(u);}
 #   define d3(x) {x;}
 #else
 #   define d1(x)
 #   define d2(u,v,w)
+#   define d2ptr(u)
 #   define d3(x)
 #   define dline(x)
 #endif

--- a/Bus-Updater/inc/flash.h
+++ b/Bus-Updater/inc/flash.h
@@ -53,7 +53,7 @@ UDP_State eraseFullFlash();
  * @warning             Function can take up to ~3.5 seconds to return.
  *                      It works on a page and sector base. Page erases are very slow ~100ms for one page
  */
-UDP_State eraseAddressRange(unsigned int startAddress, const unsigned int endAddress, const bool rangeCheck = true);
+UDP_State eraseAddressRange(uint8_t * startAddress, const uint8_t * endAddress, const bool rangeCheck = true);
 
 /**
  * @brief Checks if the address range is allowed to be programmed
@@ -64,7 +64,7 @@ UDP_State eraseAddressRange(unsigned int startAddress, const unsigned int endAdd
  *                         or false to check range of the application itself
  * @return                 true if programming is allowed, otherwise false
  */
-bool addressAllowedToProgram(unsigned int start, unsigned int length, bool isBootDescriptor = false);
+bool addressAllowedToProgram(uint8_t * start, unsigned int length, bool isBootDescriptor = false);
 
 /**
  * @brief Programs the specified number of bytes from the RAM to the specified location
@@ -78,7 +78,7 @@ bool addressAllowedToProgram(unsigned int start, unsigned int length, bool isBoo
  *                or a @ref IAP_Status
  * @warning       The function calls iap_Program which by itself calls no_interrupts().
  */
-UDP_State executeProgramFlash(unsigned int address, const byte* ram, unsigned int size, bool isBootDescriptor = false);
+UDP_State executeProgramFlash(uint8_t * address, const uint8_t * ram, unsigned int size, bool isBootDescriptor = false);
 
 
 

--- a/Bus-Updater/src/boot_descriptor_block.cpp
+++ b/Bus-Updater/src/boot_descriptor_block.cpp
@@ -145,7 +145,7 @@ uint8_t * bootLoaderLastAddress(void)
 unsigned int bootLoaderSize(void)
 {
     // includes .text and .data
-    return (_image_size);
+    return ((unsigned int)(uintptr_t)&_image_size);
 }
 
 uint8_t * flashFirstAddress(void)

--- a/Bus-Updater/src/boot_descriptor_block.cpp
+++ b/Bus-Updater/src/boot_descriptor_block.cpp
@@ -18,32 +18,32 @@
  published by the Free Software Foundation.
  -----------------------------------------------------------------------------*/
 
-// #include <sblib/internal/iap.h>
+#include <sblib/internal/iap.h>
 #include "boot_descriptor_block.h"
 #include "crc.h"
+#include <memory>
 
 #ifndef IAP_EMULATION
-extern unsigned int __base_Flash;   //!< marks the beginning of the flash memory (inserted by the linker)
+extern uint8_t __base_Flash[];      //!< marks the beginning of the flash memory (inserted by the linker)
                                     //!< used to protect the updater from killing itself with a new application downloaded over the bus
-extern unsigned int __top_Flash;    //!< marks the end of the flash memory (inserted by the linker)
+extern uint8_t __top_Flash[];       //!< marks the end of the flash memory (inserted by the linker)
                                     //!< used to protect the updater from killing itself with a new application downloaded over the bus
-extern unsigned int _image_start;   //!< marks the beginning of the bootloader firmware (inserted by the linker)
+extern uint8_t _image_start[];      //!< marks the beginning of the bootloader firmware (inserted by the linker)
                                     //!< used to protect the updater from killing itself with a new application downloaded over the bus
-extern unsigned int _image_end;     //!< marks the end of the bootloader firmware (inserted by the linker)
+extern uint8_t _image_end[];        //!< marks the end of the bootloader firmware (inserted by the linker)
                                     //!< used to protect the updater from killing itself with a new application downloaded over the bus
 extern unsigned int _image_size;    //!< marks the size of the bootloader firmware (inserted by the linker)
                                     //!< used to protect the updater from killing itself with a new application downloaded over the bus
 #else
     // for catch unit tests ///\todo move this to cpu-emulation
-    unsigned int __base_Flash = 0x0000;
-    unsigned int  __top_Flash = 0x10000;
-    unsigned int _image_start = 0x0000;
-    unsigned int _image_end = 0x2EFF;
-    unsigned int _image_size = 0x2F00;
+    uint8_t * __base_Flash = &FLASH[0x0000];
+    uint8_t *  __top_Flash = &FLASH[0x10000];
+    uint8_t * _image_start = &FLASH[0x0000];
+    uint8_t * _image_end = &FLASH[0x2F00];
+    unsigned int _image_size = _image_end - _image_start;
 #endif
 
-__attribute__((unused)) unsigned char bl_id_string[BL_ID_STRING_LENGTH] = BL_ID_STRING; // actually it's used in getAppVersion,
-                                                                                        // this is just to suppress compiler warning
+char bl_id_string[BL_ID_STRING_LENGTH] = BL_ID_STRING;
 
 
 /**
@@ -58,7 +58,7 @@ __attribute__((unused)) unsigned char bl_id_string[BL_ID_STRING_LENGTH] = BL_ID_
  * @param start
  * @return
  */
-unsigned int checkVectorTable(unsigned int start)
+unsigned int checkVectorTable(uint8_t * start)
 {
     unsigned int i;
     unsigned int * address;
@@ -67,10 +67,8 @@ unsigned int checkVectorTable(unsigned int start)
 
     for (i = 0; i < 7; i++)				// Checksum is 2's complement of entries 0 through 6
         cs += address[i];
-    //if (address[7])
 
     return (~cs+1);
-    return (address[0]);
 }
 
 unsigned int checkApplication(AppDescriptionBlock * block)
@@ -100,16 +98,17 @@ unsigned int checkApplication(AppDescriptionBlock * block)
     return (0);
 }
 
-unsigned char* getAppVersion(AppDescriptionBlock * block)
+char* getAppVersion(AppDescriptionBlock * block)
 {
-    if ((block->appVersionAddress >= applicationFirstAddress()) &&
-        (block->appVersionAddress < flashLastAddress() - sizeof(block->appVersionAddress)))
+    void * appVersionAddress = (void *)(block->appVersionAddress);
+    if ((appVersionAddress >= applicationFirstAddress()) &&
+        (appVersionAddress < flashLastAddress() - sizeof(block->appVersionAddress)))
     {
-        return ((unsigned char*) (block->appVersionAddress));
+        return (block->appVersionAddress);
     }
     else
     {
-        return (&bl_id_string[0]); // Bootloader ID is invalid (address out of range)
+        return (bl_id_string); // Bootloader ID is invalid (address out of range)
     }
 }
 
@@ -120,44 +119,44 @@ unsigned char* getAppVersion(AppDescriptionBlock * block)
  * @return      Start address of application in case of valid descriptor block,
  *              otherwise base address of firmware area, directly behind bootloader
  */
-unsigned char * getFirmwareStartAddress(AppDescriptionBlock * block)
+uint8_t * getFirmwareStartAddress(AppDescriptionBlock * block)
 {
     if (checkApplication(block))
     {
-    	return ((unsigned char *) (block->startAddress));
+    	return (block->startAddress);
     }
     else
     {
-    	return ((unsigned char *) applicationFirstAddress());
+    	return (applicationFirstAddress());
     }
 }
 
-unsigned int bootLoaderFirstAddress(void)
+uint8_t * bootLoaderFirstAddress(void)
 {
-    return ((unsigned int) (unsigned int*)&_image_start);
+    return (_image_start);
 }
 
-unsigned int bootLoaderLastAddress(void)
+uint8_t * bootLoaderLastAddress(void)
 {
     //linker sets this not correctly, so we need the -1
-    return ((unsigned int) (unsigned int*)&_image_end - 1);
+    return (_image_end - 1);
 }
 
 unsigned int bootLoaderSize(void)
 {
     // includes .text and .data
-    return ((unsigned int) (unsigned int*)&_image_size);
+    return (_image_size);
 }
 
-unsigned int flashFirstAddress(void)
+uint8_t * flashFirstAddress(void)
 {
-    return ((unsigned int) (unsigned int*)&__base_Flash);
+    return (__base_Flash);
 }
 
-unsigned int flashLastAddress(void)
+uint8_t * flashLastAddress(void)
 {
     //linker sets this not correctly, so we need the -1
-    return ((unsigned int) ((unsigned int*)&__top_Flash) - 1);
+    return (__top_Flash - 1);
 }
 
 unsigned int flashSize(void)
@@ -166,19 +165,21 @@ unsigned int flashSize(void)
     return ((flashLastAddress() - flashFirstAddress() + 1));
 }
 
-unsigned int applicationFirstAddress(void)
+uint8_t * applicationFirstAddress(void)
 {
     // replacement for #define APPLICATION_FIRST_SECTOR //!< where the application starts (BL size) + (BOOT_BLOCK_DESC_SIZE * BOOT_BLOCK_COUNT)
-    unsigned int appFirstAddress = bootLoaderFirstAddress() + bootLoaderSize();
+    uint8_t * appFirstAddress = bootLoaderFirstAddress() + bootLoaderSize();
     // all boot descriptor block's are placed in front of the application,
     // so we need for them space after bootloader and before the application
     appFirstAddress += (BOOT_BLOCK_DESC_SIZE * BOOT_BLOCK_COUNT);
-    // round up the the next flash page
-    appFirstAddress = ((appFirstAddress/FLASH_PAGE_SIZE) + 1) * FLASH_PAGE_SIZE;
-    return appFirstAddress;
+    // align to the next flash page
+    void * ptr = appFirstAddress;
+    std::size_t space = FLASH_PAGE_ALIGNMENT;
+    std::align(FLASH_PAGE_SIZE, 1, ptr, space);
+    return (uint8_t *)ptr;
 }
 
-unsigned int bootDescriptorBlockAddress(void)
+uint8_t * bootDescriptorBlockAddress(void)
 {
     // replacement for #define BOOT_DSCR_ADDRESS  (APPLICATION_FIRST_SECTOR - (BOOT_BLOCK_DESC_SIZE * BOOT_BLOCK_COUNT))
     // boot descriptor block is placed in front of the application
@@ -189,7 +190,7 @@ unsigned int bootDescriptorBlockPage(void)
 {
     // replacement for #define BOOT_BLOCK_PAGE   ((APPLICATION_FIRST_SECTOR / BOOT_BLOCK_DESC_SIZE) - 1) //!< flash page number of the application description block
     // every boot descriptor block is placed in front of the application, so subtract all of them
-    return ((applicationFirstAddress() / BOOT_BLOCK_DESC_SIZE) - BOOT_BLOCK_COUNT); //!< flash page number of the application description block
+    return iapPageOfAddress(bootDescriptorBlockAddress());
 }
 
 /** @}*/

--- a/Bus-Updater/src/bootloader.cpp
+++ b/Bus-Updater/src/bootloader.cpp
@@ -113,14 +113,14 @@ BcuBase* setup()
     serial.print(" ");
     serial.println(__TIME__);
     serial.println("Features                    : 0x", BL_FEATURES, HEX, 6);
-    serial.print("Flash      (start,end,size) : 0x", flashFirstAddress(), HEX, 6);
-    serial.print(" 0x", flashLastAddress(), HEX, 6);
+    serial.print("Flash      (start,end,size) : 0x", flashFirstAddress());
+    serial.print(" 0x", flashLastAddress());
     serial.println(" 0x", flashSize(), HEX, 6);
-    serial.print("Bootloader (start,end,size) : 0x", bootLoaderFirstAddress(), HEX, 6);
-    serial.print(" 0x", bootLoaderLastAddress(), HEX, 6);
+    serial.print("Bootloader (start,end,size) : 0x", bootLoaderFirstAddress());
+    serial.print(" 0x", bootLoaderLastAddress());
     serial.println(" 0x", bootLoaderSize(), HEX, 6);
-    serial.println("Firmware (start)            : 0x", applicationFirstAddress(), HEX, 6);
-    serial.println("Boot descriptor (start)     : 0x", bootDescriptorBlockAddress(), HEX, 6);
+    serial.println("Firmware (start)            : 0x", applicationFirstAddress());
+    serial.println("Boot descriptor (start)     : 0x", bootDescriptorBlockAddress());
     serial.println("Boot descriptor page        : 0x", bootDescriptorBlockPage(), HEX, 6);
     serial.println("Boot descriptor size        : 0x", BOOT_BLOCK_DESC_SIZE * BOOT_BLOCK_COUNT, HEX, 6);
     serial.println("Boot descriptor count       : ", BOOT_BLOCK_COUNT, DEC);
@@ -169,7 +169,7 @@ void loop()
  *
  * @param start     Start address of application
  */
-static void jumpToApplication(unsigned int start)
+static void jumpToApplication(uint8_t * start)
 {
 #ifndef IAP_EMULATION
     unsigned int StackTop = *(unsigned int *) (start);

--- a/Bus-Updater/src/decompressor.cpp
+++ b/Bus-Updater/src/decompressor.cpp
@@ -105,8 +105,8 @@ int Decompressor::pageCompletedDoFlash()
 
 		// proceed to flash the decompressed page stored in the scratchpad RAM
 		d1("Diff - Program Page at Address 0x");
-		d2((unsigned int)startAddrOfPageToBeFlashed, HEX,4);
-		lastError = executeProgramFlash((unsigned int)startAddrOfPageToBeFlashed, scratchpad, FLASH_PAGE_SIZE);
+		d2ptr(startAddrOfPageToBeFlashed);
+		lastError = executeProgramFlash(startAddrOfPageToBeFlashed, scratchpad, FLASH_PAGE_SIZE);
 		//lastError = iapProgram(startAddrOfPageToBeFlashed, scratchpad, FLASH_PAGE_SIZE);
 		//lastError = UDP_IAP_SUCCESS; // Dry RUN! for debug
 	}
@@ -258,8 +258,8 @@ uint32_t Decompressor::getCrc32() {
 	return (ccrc);
 }
 
-uint32_t Decompressor::getStartAddrOfPageToBeFlashed() {
-	return ((uint32_t)startAddrOfPageToBeFlashed);
+uint8_t * Decompressor::getStartAddrOfPageToBeFlashed() {
+	return (startAddrOfPageToBeFlashed);
 }
 
 uint32_t Decompressor::getBytesCountToBeFlashed() {

--- a/Bus-Updater/src/update.cpp
+++ b/Bus-Updater/src/update.cpp
@@ -52,7 +52,7 @@
 #define DEVICE_LOCKED   ((unsigned int ) 0x5AA55AA5)     //!< magic number for device is locked and can't be flashed
 #define DEVICE_UNLOCKED ((unsigned int ) ~DEVICE_LOCKED) //!< magic number for device is unlocked and flashing is allowed
 
-static unsigned char __attribute__ ((aligned (FLASH_RAM_BUFFER_ALIGNMENT))) ramBuffer[RAM_BUFFER_SIZE]; //!< RAM buffer used for flash operations
+static uint8_t __attribute__ ((aligned (FLASH_RAM_BUFFER_ALIGNMENT))) ramBuffer[RAM_BUFFER_SIZE]; //!< RAM buffer used for flash operations
 
 // Try to avoid direct access to these global variables.
 // It's better to use their get, set and reset functions
@@ -73,7 +73,7 @@ extern BcuUpdate bcu;
  * @param val    the unsigned int to be converted
  * @warning function doesn't perform any sanity-checks on the provided buffer
  */
-void uInt32ToStream(unsigned char * buffer, unsigned int val);
+void uInt32ToStream(uint8_t * buffer, unsigned int val);
 
 /**
  * @brief Send the flash content from startAddress to endAddress
@@ -83,11 +83,11 @@ void uInt32ToStream(unsigned char * buffer, unsigned int val);
  * @param endAddress
  */
 #if defined(DEBUG)
-void dumpFlashContent(unsigned int startAddress, unsigned int endAddress)
+void dumpFlashContent(uint8_t * startAddress, uint8_t * endAddress)
 {
     if (startAddress > endAddress)
     {
-        unsigned int temp = startAddress;
+        uint8_t * temp = startAddress;
         startAddress = endAddress;
         endAddress = temp;
     }
@@ -102,7 +102,7 @@ void dumpFlashContent(unsigned int startAddress, unsigned int endAddress)
         endAddress = flashLastAddress();
     }
 
-    dumpToSerialinIntelHex(&serial, (unsigned char *) startAddress, endAddress - startAddress + 1);
+    dumpToSerialinIntelHex(&serial, startAddress, endAddress - startAddress + 1);
 }
 #endif
 
@@ -115,14 +115,26 @@ void dumpFlashContent(unsigned int startAddress, unsigned int endAddress)
  * @return to unsigned int converted value of the 4 first bytes of buffer
  * @warning function doesn't perform any sanity-checks on the provided buffer
  */
-unsigned int streamToUIn32(unsigned char * buffer)
+unsigned int streamToUIn32(uint8_t * buffer)
 {
     return ((unsigned int)(buffer[3] << 24 | buffer[2] << 16 | buffer[1] << 8 | buffer[0]));
 }
 
+/**
+ * @brief Converts a 4 byte long provided buffer into a pointer
+ *
+ * @param buffer data to convert
+ * @return first 4 bytes of buffer converted to a pointer
+ * @warning function doesn't perform any sanity-checks on the provided buffer
+ */
+inline uint8_t * streamToPtr(uint8_t * buffer)
+{
+    return (uint8_t *) streamToUIn32(buffer);
+}
+
 ///\todo implement universal numberToStream by providing the size as parameter
 ///      and delete uInt32ToStream + uShort16ToStream
-void uInt32ToStream(unsigned char * buffer, unsigned int val)
+void uInt32ToStream(uint8_t * buffer, unsigned int val)
 {
     buffer[3] = (byte)(val >> 24);
     buffer[2] = (byte)(val >> 16);
@@ -130,7 +142,19 @@ void uInt32ToStream(unsigned char * buffer, unsigned int val)
     buffer[0] = (byte)(val & 0xff);
 }
 
-void uShort16ToStream(unsigned char * buffer, unsigned int val)
+/**
+ * @brief Converts a pointer to a 4 byte long and writes it to buffer
+ *
+ * @param buffer memory area to receive converted value
+ * @param val pointer to convert and write
+ * @warning function doesn't perform any sanity-checks on the provided buffer
+ */
+inline void ptrToStream(uint8_t * buffer, uint8_t * val)
+{
+    uInt32ToStream(buffer, (uint32_t) val);
+}
+
+void uShort16ToStream(uint8_t * buffer, unsigned int val)
 {
     buffer[1] = (byte)(val >> 8);
     buffer[0] = (byte)(val & 0xff);
@@ -238,7 +262,7 @@ void resetUPDProtocol(void)
  * @post          calls setLastErrror with UDP_IAP_SUCCESS if device is unlocked, otherwise @ref UDP_UID_MISMATCH or a @ref IAP_Status.
  * @return        always T_ACK_PDU
  */
-static unsigned char updUnlockDevice(unsigned char * data)
+static unsigned char updUnlockDevice(uint8_t * data)
 {
     if (getProgButtonState())
     { // the operator has physical access to the device -> we unlock it
@@ -287,9 +311,9 @@ static unsigned char updUnlockDevice(unsigned char * data)
  * @post          sets lastError always to UDP_IAP_SUCCESS
  * @return        always T_ACK_PDU
  */
-static unsigned char updAppVersionRequest(unsigned char * data)
+static unsigned char updAppVersionRequest(uint8_t * data)
 {
-    unsigned char* appversion;
+    char* appversion;
     appversion = getAppVersion((AppDescriptionBlock *) (applicationFirstAddress() - (1 + data[3]) * BOOT_BLOCK_DESC_SIZE));
     lastError = UDP_IAP_SUCCESS;
     prepareReturnTelegram(BL_ID_STRING_LENGTH - 1, UPD_APP_VERSION_RESPONSE);
@@ -321,7 +345,7 @@ static unsigned char updAppVersionRequest(unsigned char * data)
  * @note          device must be unlocked
  */
 /*
-static unsigned char updEraseSector(unsigned char * data)
+static unsigned char updEraseSector(uint8_t * data)
 {
     resetProtocol();
     setLastError(eraseSector(data[3]));
@@ -337,11 +361,11 @@ static unsigned char updEraseSector(unsigned char * data)
  * @return        always T_ACK_PDU
  * @note          device must be unlocked
  */
-static unsigned char updDumpFlashRange(unsigned char * data)
+static unsigned char updDumpFlashRange(uint8_t * data)
 {
 #ifdef DEBUG
-    unsigned int startAddress = streamToUIn32(&data[3]);
-    unsigned int endAddress = streamToUIn32(&data[7]);
+    uint8_t * startAddress = streamToPtr(&data[3]);
+    uint8_t * endAddress = streamToPtr(&data[7]);
     setLastError(UDP_IAP_SUCCESS);
     dumpFlashContent(startAddress, endAddress);
 #else
@@ -359,10 +383,10 @@ static unsigned char updDumpFlashRange(unsigned char * data)
  * @return        always T_ACK_PDU
  * @note          device must be unlocked
  */
-static unsigned char updEraseAddressRange(unsigned char * data)
+static unsigned char updEraseAddressRange(uint8_t * data)
 {
-    unsigned int startAddress = streamToUIn32(&data[3]);
-    unsigned int endAddress = streamToUIn32(&data[7]);
+    uint8_t * startAddress = streamToPtr(&data[3]);
+    uint8_t * endAddress = streamToPtr(&data[7]);
     setLastError(eraseAddressRange(startAddress, endAddress));
     resetUPDProtocol();
     return (T_ACK_PDU);
@@ -391,7 +415,7 @@ static unsigned char updEraseFullFlash()
  * @return        always T_ACK_PDU
  * @note          device must be unlocked
  */
-static unsigned char updSendData(unsigned char * data, unsigned int nCount)
+static unsigned char updSendData(uint8_t * data, unsigned int nCount)
 {
     ramLocation = data[3];// * 11;  // Current Byte position as message number with 11 Bytes payload each
     nCount --;                      // 1 Bytes abziehen, da diese für die Nachrichtennummer verwendet wird
@@ -405,7 +429,7 @@ static unsigned char updSendData(unsigned char * data, unsigned int nCount)
 
     bytesReceived += nCount;
 
-    memcpy((void *) &ramBuffer[ramLocation], data + 4, nCount); //ab dem 4. Byte sind die Daten verfügbar
+    memcpy(&ramBuffer[ramLocation], data + 4, nCount); //ab dem 4. Byte sind die Daten verfügbar
     setLastError(UDP_IAP_SUCCESS);
     for(unsigned int i=0; i<nCount; i++)
     {
@@ -426,11 +450,11 @@ static unsigned char updSendData(unsigned char * data, unsigned int nCount)
  * @note          device must be unlocked
  * @warning       The function calls @ref executeProgramFlash which calls @ref iap_Program which by itself calls @ref no_interrupts().
  */
-static unsigned char updProgram(unsigned char * data)
+static unsigned char updProgram(uint8_t * data)
 {
     unsigned int crcRamBuffer;
     unsigned int flash_count = streamToUIn32(data + 3);
-    unsigned int address = streamToUIn32(data + 3 + 4);
+    uint8_t * address = streamToPtr(data + 3 + 4);
 
     if (!addressAllowedToProgram(address, flash_count))
     {
@@ -465,7 +489,7 @@ static unsigned char updProgram(unsigned char * data)
         flash_count = FLASH_PAGE_SIZE;
 
     d3(serial.print("writing ", flash_count));
-    d3(serial.print(" bytes @ 0x", address, HEX, 8));
+    d3(serial.print(" bytes @ 0x", address));
     d3(serial.println(" crc 0x", crcRamBuffer, HEX, 8));
 
     bytesFlashed += flash_count;
@@ -483,7 +507,7 @@ static unsigned char updProgram(unsigned char * data)
  *
  * @return always T_ACK_PDU
  */
-static unsigned char updRequestBootloaderIdentity(unsigned char * data)
+static unsigned char updRequestBootloaderIdentity(uint8_t * data)
 {
     unsigned int majorVersionUpdater = streamToUIn32(data + 3);
     unsigned int minorVersionUpdater = streamToUIn32(data + 3 + 4);
@@ -507,14 +531,14 @@ static unsigned char updRequestBootloaderIdentity(unsigned char * data)
 
     unsigned int bootloaderIdentity = BL_IDENTITY;
     unsigned int bootloaderFeatures = BL_FEATURES;
-    unsigned int appFirstAddress = applicationFirstAddress();
+    uint8_t * appFirstAddress = applicationFirstAddress();
     prepareReturnTelegram(12, UPD_RESPONSE_BL_IDENTITY);
     uInt32ToStream(bcu.sendTelegram + 10, bootloaderIdentity);  // Bootloader identity
     uInt32ToStream(bcu.sendTelegram + 14, bootloaderFeatures);  // Bootloader features
-    uInt32ToStream(bcu.sendTelegram + 18, appFirstAddress);     // application first possible start address
+    ptrToStream(bcu.sendTelegram + 18, appFirstAddress);        // application first possible start address
     d3(serial.print("BL ID 0x", bootloaderIdentity, HEX, 8));
     d3(serial.print("    BL feature 0x", bootloaderFeatures, HEX, 8));
-    d3(serial.println("    FW start   0x", appFirstAddress, HEX, 8));
+    d3(serial.println("    FW start   0x", appFirstAddress));
 
     return (T_ACK_PDU);
 }
@@ -576,19 +600,19 @@ static unsigned char udpRequestBootDescriptionBlock()
 
     if (!valid)
     {
-        bootDescr->startAddress = 0xFFFFFFFF;
-        bootDescr->endAddress = bootDescr->startAddress;
-        bootDescr->appVersionAddress = bootDescr->startAddress;
-        bootDescr->crc = bootDescr->startAddress;
+        bootDescr->startAddress = (uint8_t *)-1;
+        bootDescr->endAddress = (uint8_t *)-1;
+        bootDescr->appVersionAddress = (char *)-1;
+        bootDescr->crc = -1;
     }
 
     prepareReturnTelegram(12, UPD_RESPONSE_BOOT_DESC);
     memcpy(bcu.sendTelegram + 10, bootDescr, 12); // startAddress, endAddress, crc
 
-    d3(serial.print("FW start@ 0x", bootDescr->startAddress , HEX, 8));   // Firmware start address
-    d3(serial.print(" end@ 0x", bootDescr->endAddress, HEX, 8));        // Firmware end address
-    d3(serial.print(" Desc.@ 0x", bootDescr->appVersionAddress, HEX, 8)); // Firmware App descriptor address (for getAppVersion())
-    d3(serial.println(" CRC : 0x", bootDescr->crc, HEX, 8));                // Firmware CRC
+    d3(serial.print("FW start@ 0x", bootDescr->startAddress));   // Firmware start address
+    d3(serial.print(" end@ 0x", bootDescr->endAddress));        // Firmware end address
+    d3(serial.print(" Desc.@ 0x", bootDescr->appVersionAddress)); // Firmware App descriptor address (for getAppVersion())
+    d3(serial.println(" CRC : 0x", (uintptr_t)bootDescr->crc, HEX, 8));                // Firmware CRC
     return (T_ACK_PDU);
 }
 
@@ -602,8 +626,8 @@ static unsigned char udpRequestBootDescriptionBlock()
  */
 static unsigned char updRequestData()
 {
-    /*
-     memcpy(bcu.sendTelegram + 9, (void *)address, count);
+     /*
+     memcpy(bcu.sendTelegram + 9, address, count);
      bcu.sendTelegram[5] = 0x63 + count;
      bcu.sendTelegram[6] = 0x42;
      bcu.sendTelegram[7] = 0x40 | count;
@@ -682,10 +706,10 @@ static unsigned char updUnkownCommand()
  * @note          device must be unlocked
  * @warning       The function calls @ref executeProgramFlash which calls @ref iap_Program which by itself calls @ref no_interrupts().
  */
-static unsigned char updUpdateBootDescriptorBlock(unsigned char * data)
+static unsigned char updUpdateBootDescriptorBlock(uint8_t * data)
 {
     unsigned int count = streamToUIn32(data + 3); // length of the descriptor
-    unsigned int address;
+    uint8_t * address;
     unsigned int crc;
     UDP_State result = UDP_NOT_IMPLEMENTED;
 
@@ -715,7 +739,7 @@ static unsigned char updUpdateBootDescriptorBlock(unsigned char * data)
     address = bootDescriptorBlockAddress();                // start address of boot block descriptor
     crc = crc32(0xFFFFFFFF, ramBuffer, count);  // checksum on used length only
 
-    d3(serial.println("Desc.      @ 0x", address, HEX, 4));
+    d3(serial.println("Desc.      @ 0x", address));
     d3(serial.println("Desc.    CRC 0x", crc, HEX, 8));
     d3(serial.println("Received CRC 0x", streamToUIn32(data + 7), HEX, 8));
     // compare calculated crc with the one we received for this packet
@@ -732,7 +756,7 @@ static unsigned char updUpdateBootDescriptorBlock(unsigned char * data)
 
     d3(serial.println("CRC MATCH, comparing MCUs BootDescriptor: count: ", count));
     //If received descriptor is not equal to current one, flash it
-    if(memcmp((byte *) address, ramBuffer, count) == 0)
+    if(memcmp(address, ramBuffer, count) == 0)
     {
         d3(serial.println("is equal, skipping"));
         result = UDP_IAP_SUCCESS;
@@ -791,7 +815,7 @@ static unsigned char updUpdateBootDescriptorBlock(unsigned char * data)
  * @note          device must be unlocked
  * @warning       The function calls @ref Decompressor.pageCompletedDoFlash which calls @ref iap_Program which by itself calls @ref no_interrupts().
  */
-static unsigned char updSendDataToDecompress(unsigned char * data, unsigned int nCount)
+static unsigned char updSendDataToDecompress(uint8_t * data, unsigned int nCount)
 {
 #ifndef DECOMPRESSOR
     dline("-->not implemented")
@@ -824,17 +848,17 @@ static unsigned char updSendDataToDecompress(unsigned char * data, unsigned int 
  * @note          device must be unlocked
  * @warning       The function calls @ref Decompressor.pageCompletedDoFlash which calls @ref iap_Program which by itself calls @ref no_interrupts().
  */
-static unsigned char updProgramDecompressedDataToFlash(unsigned char * data)
+static unsigned char updProgramDecompressedDataToFlash(uint8_t * data)
 {
 #ifndef DECOMPRESSOR
     setLastError(UDP_NOT_IMPLEMENTED);
 #else
     unsigned int count = decompressor.getBytesCountToBeFlashed();
-    unsigned int address = decompressor.getStartAddrOfPageToBeFlashed();
+    uint8_t * address = decompressor.getStartAddrOfPageToBeFlashed();
     unsigned int crc;
 
     d1("\n\rFlash Diff address 0x");
-    d2(address,HEX,4);
+    d2ptr(address);
     d1(" length: ");
     d2(count,DEC,3);
 
@@ -869,7 +893,7 @@ static unsigned char updProgramDecompressedDataToFlash(unsigned char * data)
      return (T_ACK_PDU);
 }
 
-unsigned char handleApciMemoryWriteRequest(unsigned char * data)
+unsigned char handleApciMemoryWriteRequest(uint8_t * data)
 {
     unsigned int count = data[0] & 0x0f;
     byte updCommand = data[2];

--- a/Bus-Updater/src/update.cpp
+++ b/Bus-Updater/src/update.cpp
@@ -129,7 +129,7 @@ unsigned int streamToUIn32(uint8_t * buffer)
  */
 inline uint8_t * streamToPtr(uint8_t * buffer)
 {
-    return (uint8_t *) streamToUIn32(buffer);
+    return FLASH_BASE_ADDRESS + streamToUIn32(buffer);
 }
 
 ///\todo implement universal numberToStream by providing the size as parameter
@@ -151,7 +151,7 @@ void uInt32ToStream(uint8_t * buffer, unsigned int val)
  */
 inline void ptrToStream(uint8_t * buffer, uint8_t * val)
 {
-    uInt32ToStream(buffer, (uint32_t) val);
+    uInt32ToStream(buffer, val - FLASH_BASE_ADDRESS);
 }
 
 void uShort16ToStream(uint8_t * buffer, unsigned int val)

--- a/doc/TypeUsage.md
+++ b/doc/TypeUsage.md
@@ -1,0 +1,20 @@
+Type Usage
+===
+
+The following types are used in the code base:
+
+* **Memory address (Flash, RAM)**: `uint8_t *` (in few cases also `void *` or `uintptr_t`)
+
+  Memory is an array of bytes. Therefore, `uint8_t *` is the best type for generic memory addresses.
+  
+  Sometimes, developers recommend to use `void *` for this. That is problematic as any pointer is implicitly convertible
+  to `void *`, so the code actually becomes less clear and also less type safe. However, this type does make sense
+  to use for functions that need to accept generic memory addresses (pointers) for whatever reason, e.g. debug logging
+  or the canonical `memcpy` and `memcmp` functions.
+
+  And there's also `uintptr_t`. This is not a pointer type per se, but a pointer-sized unsigned integer, i.e. on a
+  32-bit target platform it is 32 bits wide and on a 64-bit target platform 64 bits wide. This is useful for data
+  structures that need to represent generic data where the concrete data depends on some other value. For example, the
+  data structure for IAP commands has a `cmd` field and the command's parameters can have any type as their
+  interpretation depends on the value of `cmd`. So in cases like this, a `uintptr_t` can be used as it can store any
+  integer, and is big enough for pointers as well.

--- a/sblib/inc/sblib/internal/iap.h
+++ b/sblib/inc/sblib/internal/iap.h
@@ -43,14 +43,6 @@ enum IAP_Status
 unsigned int iapSectorOfAddress(const byte* address);
 
 /**
- * Get the index of the FLASH sector for the passed address.
- *
- * @param address - the address inside the FLASH
- * @return The sector index of the address.
- */
-unsigned int iapSectorOfAddress(const unsigned int address);
-
-/**
  * Get the index of the FLASH page for the passed address.
  *
  * @param address - the address inside the FLASH
@@ -59,20 +51,12 @@ unsigned int iapSectorOfAddress(const unsigned int address);
 unsigned int iapPageOfAddress(const byte* address);
 
 /**
- * Get the index of the FLASH page for the passed address.
- *
- * @param address - the address inside the FLASH
- * @return The sector index of the address.
- */
-unsigned int iapPageOfAddress(const unsigned int address);
-
-/**
  * Get the address of the given FLASH page index.
  *
  * @param page - the page index inside the FLASH
  * @return The address of the given page index.
  */
-unsigned int iapAddressOfPage(const unsigned int page);
+uint8_t * iapAddressOfPage(const unsigned int page);
 
 /**
  * Get the address of the given FLASH sector index.
@@ -80,7 +64,7 @@ unsigned int iapAddressOfPage(const unsigned int page);
  * @param sector - the sector index inside the FLASH
  * @return The address of the given sector index.
  */
-unsigned int iapAddressOfSector(const unsigned int sector);
+uint8_t * iapAddressOfSector(const unsigned int sector);
 
 /**
  * Erase the specified sector.

--- a/sblib/inc/sblib/mem_mapper.h
+++ b/sblib/inc/sblib/mem_mapper.h
@@ -195,7 +195,7 @@ private:
     unsigned int getUIntX(int virtAddress, int length);
     int setUIntX(int virtAddress, int length, int val);
 
-    unsigned int flashBase; //memory layout: flashBase + 0 = allocTable, flashBase + 1 = usableMemory
+    uint8_t * flashBase; //memory layout: flashBase + 0 = allocTable, flashBase + 1 = usableMemory
     unsigned int flashBasePage;
 
     unsigned int flashSize;

--- a/sblib/inc/sblib/platform.h
+++ b/sblib/inc/sblib/platform.h
@@ -53,15 +53,15 @@ unsigned int* ioconPointer(int port, int pinNum);
 
 
 #ifdef IAP_EMULATION
-  extern unsigned char FLASH[];
-# define LPC_FLASH_BASE (intptr_t)FLASH
+  extern uint8_t FLASH[];
+# define LPC_FLASH_BASE (FLASH)
 #else
 #ifndef LPC_FLASH_BASE
   #define LPC_FLASH_BASE 0
 #endif
 #endif
 
-#define FLASH_BASE_ADDRESS ((unsigned char *)LPC_FLASH_BASE) //!< The base address of the flash
+#define FLASH_BASE_ADDRESS   ((uint8_t *)LPC_FLASH_BASE) //!< The base address of the flash
 
 #define FLASH_SECTOR_SIZE    (0x1000)              //!< The size of a flash sector in bytes
 #define FLASH_PAGE_SIZE      (0x100)               //!< The size of a flash page in bytes

--- a/sblib/inc/sblib/print.h
+++ b/sblib/inc/sblib/print.h
@@ -86,7 +86,16 @@ public:
      *
      * @return The number of bytes that were written.
      */
-    int print(unsigned int value, Base base = DEC, int digits = -1);
+    int print(uintptr_t value, Base base = DEC, int digits = -1);
+
+    /**
+     * Print a pointer.
+     *
+     * @param ptr - the pointer to print
+     *
+     * @return The number of bytes that were written.
+     */
+    int print(const void * ptr);
 
     /**
      * Print a zero terminated string followed by an unsigned number.
@@ -98,7 +107,17 @@ public:
      *
      * @return The number of bytes that were written.
      */
-    int print(const char* str, unsigned int value, Base base = DEC, int digits = -1);
+    int print(const char* str, uintptr_t value, Base base = DEC, int digits = -1);
+
+    /**
+     * Print a zero terminated string followed by a pointer.
+     *
+     * @param str - the string to print
+     * @param ptr - the pointer to print
+     *
+     * @return The number of bytes that were written.
+     */
+    int print(const char* str, const void * ptr);
 
     /**
      * Print a new line by sending a carriage return '\r' (ASCII 13) followed
@@ -149,7 +168,16 @@ public:
      *
      * @return The number of bytes that were written.
      */
-    int println(unsigned int value, Base base = DEC, int digits = -1);
+    int println(uintptr_t value, Base base = DEC, int digits = -1);
+
+    /**
+     * Print a pointer followed by a new line.
+     *
+     * @param ptr - the pointer to print
+     *
+     * @return The number of bytes that were written.
+     */
+    int println(const void * ptr);
 
     /**
      * Print a zero terminated string followed by an unsigned number and a new line.
@@ -161,7 +189,17 @@ public:
      *
      * @return The number of bytes that were written.
      */
-    int println(const char* str, unsigned int value, Base base = DEC, int digits = -1);
+    int println(const char* str, uintptr_t value, Base base = DEC, int digits = -1);
+
+    /**
+     * Print a zero terminated string followed by a pointer and a new line.
+     *
+     * @param str - the string to print
+     * @param ptr - the pointer to print
+     *
+     * @return The number of bytes that were written.
+     */
+    int println(const char* str, const void * ptr);
 
     /**
      * Write a zero terminated string.
@@ -209,6 +247,16 @@ inline int Print::print(const char* str)
     return this->write(str);
 }
 
+inline int Print::print(const void * ptr)
+{
+    return print((uintptr_t)ptr, HEX, sizeof(void *));
+}
+
+inline int Print::print(const char* str, const void * ptr)
+{
+    return print(str, (uintptr_t)ptr, HEX, sizeof(void *));
+}
+
 inline int Print::println(const char* str)
 {
     return this->write(str) + println();
@@ -219,9 +267,19 @@ inline int Print::println(int value, Base base, int digits)
     return print(value, base, digits) + println();
 }
 
-inline int Print::println(unsigned int value, Base base, int digits)
+inline int Print::println(uintptr_t value, Base base, int digits)
 {
     return print(value, base, digits) + println();
+}
+
+inline int Print::println(const void * ptr)
+{
+    return print(ptr) + println();
+}
+
+inline int Print::println(const char* str, const void * ptr)
+{
+    return print(str, ptr) + println();
 }
 
 #endif /*sblib_print_h*/

--- a/sblib/src/i2c.cpp
+++ b/sblib/src/i2c.cpp
@@ -162,8 +162,6 @@ struct i2c_slave_interface {
 	I2C_EVENTHANDLER_T event;
 };
 
-void* test =0;
-
 /* I2C interfaces */
 static struct i2c_interface i2c[I2C_NUM_INTERFACE] = {
 	{LPCOPEN_I2C, /*SYSCTL_CLOCK_I2C,*/ Chip_I2C_EventHandler, 0, 0, 0, 0}

--- a/sblib/src/mem_mapper.cpp
+++ b/sblib/src/mem_mapper.cpp
@@ -19,15 +19,15 @@
 
 
 MemMapper::MemMapper(unsigned int flashBase, unsigned int flashSize, bool autoAddPage) :
-        flashBase(flashBase), flashSize(flashSize), autoAddPage(autoAddPage)
+        flashBase(FLASH_BASE_ADDRESS + flashBase), flashSize(flashSize), autoAddPage(autoAddPage)
 {
     flashSizePages = flashSize / FLASH_PAGE_SIZE;
-    flashBasePage = ((unsigned int) flashBase) / FLASH_PAGE_SIZE;
+    flashBasePage = iapPageOfAddress(this->flashBase);
     lastAllocated = 0; // means: nothing allocated in this run
     writePage = 0;
     allocTableModified = false;
     flashMemModified = false;
-    memcpy(allocTable, (byte *)flashBase, FLASH_PAGE_SIZE);
+    memcpy(allocTable, this->flashBase, FLASH_PAGE_SIZE);
     // Quick check if there is more than one zero on the allocTable, a certain
     // sign of table corruption. In this case, clear the table (set all 0xff).
     // This is necessary because a corrupted table leads to all sorts of
@@ -69,7 +69,7 @@ int MemMapper::doFlash(void) const
         {
             fatalError();
         }
-        if (iapProgram((byte *)flashBase, allocTable, FLASH_PAGE_SIZE) != IAP_SUCCESS)
+        if (iapProgram(flashBase, allocTable, FLASH_PAGE_SIZE) != IAP_SUCCESS)
         {
             fatalError();
         }
@@ -82,7 +82,7 @@ int MemMapper::doFlash(void) const
         {
             fatalError();
         }
-        if (iapProgram((byte *) (writePage << 8), writeBuf, FLASH_PAGE_SIZE)
+        if (iapProgram(iapAddressOfPage(writePage), writeBuf, FLASH_PAGE_SIZE)
                 != IAP_SUCCESS)
         {
             fatalError();
@@ -187,7 +187,7 @@ int MemMapper::writeMem(int virtAddress, byte data)
         writePage = flashPageNum;
         if (writePage != 0)
         { // swap flash page into write buffer
-            memcpy(writeBuf, (byte *)(writePage << 8), FLASH_PAGE_SIZE);
+            memcpy(writeBuf, iapAddressOfPage(writePage), FLASH_PAGE_SIZE);
         }
     }
 
@@ -245,7 +245,7 @@ int MemMapper::readMem(int virtAddress, byte &data, bool forceFlash)
         data = writeBuf[virtAddress & 0xff];
     } else
     {
-        data = ((byte*) (flashPageNum << 8))[virtAddress & 0xff];
+        data = iapAddressOfPage(flashPageNum)[virtAddress & 0xff];
     }
     return MEM_MAPPER_SUCCESS;
 }
@@ -299,7 +299,7 @@ byte* MemMapper::memoryPtr(int virtAddress, bool forceFlash) const
     {
         return writeBuf + (virtAddress & 0xff);
     }
-    return ((byte*) (flashPageNum << 8) + (virtAddress & 0xff));
+    return (iapAddressOfPage(flashPageNum) + (virtAddress & 0xff));
 }
 
  unsigned char MemMapper::getUInt8(int virtAddress)

--- a/sblib/src/print.cpp
+++ b/sblib/src/print.cpp
@@ -36,7 +36,7 @@ int Print::print(const char* str, int value, Base base, int digits)
     return wlen;
 }
 
-int Print::print(unsigned int value, Base base, int digits)
+int Print::print(uintptr_t value, Base base, int digits)
 {
     byte buf[PRINTBUF_SIZE]; // need the maximum size for binary printing
     byte ch;
@@ -57,7 +57,7 @@ int Print::print(unsigned int value, Base base, int digits)
     return write((byte*) pos, buf + PRINTBUF_SIZE - pos);
 }
 
-int Print::print(const char* str, unsigned int value, Base base, int digits)
+int Print::print(const char* str, uintptr_t value, Base base, int digits)
 {
     int wlen = print(str);
     wlen += print(value, base, digits);
@@ -87,7 +87,7 @@ int Print::write(const char* str)
     return 0;
 }
 
-int Print::println(const char* str, unsigned int value, Base base, int digits)
+int Print::println(const char* str, uintptr_t value, Base base, int digits)
 {
     int wlen = print(str, value, base, digits);
     wlen += println();

--- a/sblib/src/print.cpp
+++ b/sblib/src/print.cpp
@@ -26,7 +26,7 @@ int Print::print(int value, Base base, int digits)
         --digits;
     }
 
-    return print((unsigned int) value, base, digits) + wlen;
+    return print((uintptr_t) value, base, digits) + wlen;
 }
 
 int Print::print(const char* str, int value, Base base, int digits)

--- a/test/sblib/cpu-emu/system_lpc11xx.c
+++ b/test/sblib/cpu-emu/system_lpc11xx.c
@@ -72,12 +72,12 @@ void IAP_Init_Flash(unsigned char value)
     memset(FLASH, value, FLASH_SIZE);
 }
 
-void IAP_Call (unsigned long * cmd, unsigned long * stat)
+void IAP_Call (uintptr_t * cmd, uintptr_t * stat)
 {
     unsigned int i;
     unsigned int end;
-    unsigned int * rom;
-    unsigned int * ram;
+    uint8_t * rom;
+    uint8_t * ram;
 
     * stat = CMD_SUCCESS;
     switch (* cmd)
@@ -98,13 +98,18 @@ void IAP_Call (unsigned long * cmd, unsigned long * stat)
         iap_calls [I_BLANK_CHECK]++;
         i    =  * (cmd + 1)      * SECTOR_SIZE;
         end  = (* (cmd + 2) + 1) * SECTOR_SIZE;
+        if (i >= end)
+        {
+            * stat = INVALID_COMMAND;
+            break;
+        }
         for (; i < end; i++)
         {
-        	if (i >= FLASH_SIZE)
-        	{
-        		* stat = INVALID_SECTOR;
-        		break;
-        	}
+            if (i >= FLASH_SIZE)
+            {
+                * stat = INVALID_SECTOR;
+                break;
+            }
             if (FLASH [i] != 0xFF)
             {
                 * stat = SECTOR_NOT_BLANK;
@@ -114,15 +119,15 @@ void IAP_Call (unsigned long * cmd, unsigned long * stat)
         break;
     case IAP_COPY_RAM2FLASH :
         iap_calls [I_RAM2FLASH]++;
-        rom = (unsigned int *) (int) (* (cmd + 1));
-        ram = (unsigned int *) (* (cmd + 2));
+        rom = (uint8_t *) (* (cmd + 1));
+        ram = (uint8_t *) (* (cmd + 2));
         i   = * (cmd + 3);
         memcpy (rom, ram, i);
         break;
     case IAP_COMPARE :
         iap_calls [I_COMPARE]++;
-        rom = (unsigned int *) (* (cmd + 1));
-        ram = (unsigned int *) (* (cmd + 2));
+        rom = (uint8_t *) (* (cmd + 1));
+        ram = (uint8_t *) (* (cmd + 2));
         i   = * (cmd + 3);
         if (memcmp (rom, ram, i) != 0)
         {
@@ -132,7 +137,7 @@ void IAP_Call (unsigned long * cmd, unsigned long * stat)
 
     case IAP_READ_UID:
         iap_calls [I_READ_UID]++;
-        unsigned char guid[16] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16};
+        uint8_t guid[16] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16};
         cmd += 6; //points now to p.res
         memcpy(cmd, &guid, 16);
         break;


### PR DESCRIPTION
This renders a bunch of type casts unnecessary and helps to find and fix issues like the one in #53 way earlier.

⚠️ There are a few changes in this PR that are more risky than the stuff I proposed for inclusion previously. ⚠️ 

Especially, the changes to the `IAP_Parameter` data structure as well as the external variables inserted by the linker in Bus-Updater and BootloaderLoader have some very high potential for breakage. I've quadruple-checked everything and did the best I could, but since I'm *still* in the planning stage for my test hardware setup, I did not test this on real hardware. So handle with care.