### PR TITLE
Improve compiler compatibility

### DIFF
--- a/sblib/inc/sblib/platform.h
+++ b/sblib/inc/sblib/platform.h
@@ -10,6 +10,19 @@
 #ifndef sblib_platform_h
 #define sblib_platform_h
 
+// Per Herb Sutter, the register keyword did not have any effect on C++ programs at all:
+//
+//     https://www.drdobbs.com/keywords-that-arent-or-comments-by-anoth/184403859
+//
+// That was back in 2003, but ARM still used the keyword in CMSIS. Nowadays, with C++17
+// using register yields the following
+//
+//     warning: ISO C++17 does not allow 'register' storage class specifier [-Wregister]
+//
+// As compiler output is indeed exactly the same, regardless of whether register is
+// specified or not, it's ok to hide it from the compiler with the preprocessor's help.
+#define register
+
 #if defined(__LPC11XX__)
 #include <LPC11xx.h>
 /**

--- a/sblib/inc/sblib/types.h
+++ b/sblib/inc/sblib/types.h
@@ -197,4 +197,13 @@ enum TimerPWM
 #define ALWAYS_INLINE inline
 #endif
 
+/**
+ * For compatibility across different language versions: GNU C++ has BIG_ENDIAN and LITTLE_ENDIAN
+ * whereas ISO C++ has _BIG_ENDIAN and _LITTLE_ENDIAN.
+ */
+#if !defined ( BIG_ENDIAN )
+#define BIG_ENDIAN _BIG_ENDIAN
+#define LITTLE_ENDIAN _LITTLE_ENDIAN
+#endif /* BIG_ENDIAN */
+
 #endif /*sblib_types_h*/

--- a/sblib/inc/sblib/utils.h
+++ b/sblib/inc/sblib/utils.h
@@ -71,7 +71,7 @@ int hashUID(byte* uid, const int len_uid, byte* hash, const int len_hash);
  *
  *        OFFSET_OF(ex,c) returns 2
  */
-#define OFFSET_OF(type, field)  ((unsigned int) &(((type *) 0)->field))
+#define OFFSET_OF(type, field)  (offsetof(type, field))
 
 /**
  * Include the C++ code snippet if DEBUG is defined, do not include the code

--- a/test/sblib/src/protocol.cpp
+++ b/test/sblib/src/protocol.cpp
@@ -8,10 +8,10 @@
  *  published by the Free Software Foundation.
  */
 
+#include "protocol.h"
 #include <sblib/internal/variables.h>
 #include <sblib/internal/iap.h>
 #include <sblib/bits.h>
-#include "protocol.h"
 
 extern unsigned int wfiSystemTimeInc;
 


### PR DESCRIPTION
Together with #55, these changes allow me to compile the projects with GCC 12.2 in MSYS2, package mingw-w64-ucrt-x86_64-gcc, with the 64-bit compile target -- and the tests succeed, too! I've extracted them into this separate PR as they are more about compatibility with different C++ language versions and flavors than about memory addressing.

Please see individual commit and code comments for details and reasoning.