### PR TITLE
Handle collisions gracefully

### DIFF
--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -213,11 +213,10 @@ public:
 		SEND_BIT_0,						//!< Send the first bit of the current byte
 		SEND_BITS_OF_BYTE,				//!< Send the bits of the current byte
 		SEND_WAIT_FOR_HIGH_BIT_END,		//!< Send high bit(s) and wait for receiving a the falling edge of our next 0-bit.
-		SEND_WAIT_FOR_NEXT_TX_CHAR,		//!< Wait between two transmissions, cap disabled, timeout: start sending next char
+		SEND_END_OF_BYTE,				//!< Middle of stop bit reached, decide what to do next
 		SEND_END_OF_TX,					//!< Finish sending current byte
 		SEND_WAIT_FOR_RX_ACK_WINDOW,	//!< after sending we wait for the ack receive window to start, only timeout event enabled
-		SEND_WAIT_FOR_RX_ACK,			//!< after sending we wait for the ack in the ack receive window, cap event: rx start, timeout: repeat tel
-		STATE_END
+		SEND_WAIT_FOR_RX_ACK			//!< after sending we wait for the ack in the ack receive window, cap event: rx start, timeout: repeat tel
     };
 
     /**
@@ -364,7 +363,6 @@ private:
 
 #define TX_OK 0                     //!< No error
 #define TX_STARTBIT_BUSY_ERROR 1	//!< bus is busy few us before we intended to send a start bit
-#define TX_TIMING_ERROR 2			//!< error during the sending of bits (low bit after high bit was not detected
 #define TX_NACK_ERROR 4				//!< we received a NACK
 #define TX_ACK_TIMEOUT_ERROR 8		//!< we did not received an ACK after sending in the respective time window
 #define TX_REMOTE_BUSY_ERROR 16		//!< AFTER SENDING, REMOTE SIDE SENDS busy BACK

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -500,7 +500,6 @@ void Bus::handleTelegram(bool valid)
 	}
 	else if (nextByteIndex == 1 && parity)   // Received a spike or a bus acknowledgment, only parity, no checksum
 	{
-		currentByte &= 0xff;
 		tb_h( 907, currentByte, tb_in);
 		if ((currentByte == SB_BUS_ACK) && ((rx_error & RX_CHECKSUM_ERROR) == RX_CHECKSUM_ERROR))
         {
@@ -785,6 +784,8 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 
 		if (timeout)  // Timer timeout: end of byte
 		{
+			currentByte &= 0xff;
+
 			// check bit0 and bit 1 of first byte for low level preamble bits
 			if ( (!nextByteIndex) && (currentByte & PREAMBLE_MASK) )
 				rx_error |= RX_PREAMBLE_ERROR;// preamble error, continue to read bytes - possibility to discard the telegram at higher layer

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -1311,7 +1311,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 		tx_error|= TX_ACK_TIMEOUT_ERROR; // todo  ack timeout - inform upper layer on error state and repeat tx if needed
 		state = Bus::WAIT_50BT_FOR_NEXT_RX_OR_PENDING_TX_OR_IDLE;
 
-		//timer is counting since last stop bit so we need to add the ACK_WAIT_TIME and the char-tx time of 11bits to the 50BT till idle for repated frames
+		//timer is counting since last stop bit so we need to wait 50BT till idle for repeated frames (see KNX spec v2.1 3/2/2 2.3.1 Figure 38)
 		timer.match(timeChannel, SEND_WAIT_TIME - PRE_SEND_TIME);
 
 		timer.captureMode(captureChannel, FALLING_EDGE| INTERRUPT  );// todo disable cap int during wait to increase the robustness on bus spikes

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -1309,7 +1309,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 		state = Bus::WAIT_50BT_FOR_NEXT_RX_OR_PENDING_TX_OR_IDLE;
 
 		//timer is counting since last stop bit so we need to add the ACK_WAIT_TIME and the char-tx time of 11bits to the 50BT till idle for repated frames
-		timer.match(timeChannel, ACK_WAIT_TIME + BYTE_TIME_INCL_STOP + SEND_WAIT_TIME - PRE_SEND_TIME);
+		timer.match(timeChannel, SEND_WAIT_TIME - PRE_SEND_TIME);
 
 		timer.captureMode(captureChannel, FALLING_EDGE| INTERRUPT  );// todo disable cap int during wait to increase the robustness on bus spikes
 		timer.matchMode(timeChannel, INTERRUPT | RESET); // timer reset after timeout to have ref point in next RX/TX state

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -1201,10 +1201,12 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 
 		// timeout event, i.e. sent all 1 bits without any collisions, now are in stop bit
 		state = Bus::SEND_END_OF_BYTE;
+		timer.captureMode(captureChannel, FALLING_EDGE);
 
 		// Completed transmission of parity bit and are in the middle of the stop bit transmission.
 		// What do we need to do next?
 	case Bus::SEND_END_OF_BYTE:
+		tb_t( state, ttimer.value(), tb_in);
 		if (nextByteIndex < sendTelegramLen && !sendAck)
 		{
 			// There are more bytes to send. Finish stop bit, send two fill bits, and start bit pulse of next byte.

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -1053,6 +1053,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 		 * n-bit low pulse end now after 35us by time match interrupt, send next bit of byte till end of byte (stop bit)
 		 * **/
 	case Bus::SEND_BITS_OF_BYTE:
+	{
 		tb_t( SEND_BITS_OF_BYTE, ttimer.value(), tb_in);
 		//tb_h( SEND_BITS_OF_BYTE+100, bitMask, tb_in);
 		//tb_d( SEND_BITS_OF_BYTE+200, time, tb_in);
@@ -1098,6 +1099,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 
 		timer.match(timeChannel, time); // interrupt at end of low/high bit pulse - next raising edge or after stop bit + 2 wait bits
 		break;
+	}
 
 
 		/* SEND_WAIT_FOR_HIGH_BIT_END

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -1126,7 +1126,6 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 				tb_t( state+300, ttimer.value(), tb_in);
 
 				// A collision. Stop sending and switch to receiving the current transmission.
-				D(digitalWrite(PIO1_4, 1));  // purple
 				collision = true;
 				tx_error |= TX_COLLISION_ERROR;
 				rx_error = 0;

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -1209,7 +1209,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 			// There are more bytes to send. Finish stop bit, send two fill bits, and start bit pulse of next byte.
 			time = 3 * BIT_TIME;
 			state = Bus::SEND_BIT_0;  // state for bit-0 of next byte to send
-			timer.match(pwmChannel, time - BIT_PULSE_TIME - timer.value()); // start of pulse for next low bit - falling edge on bus will not trigger cap interrupt
+			timer.match(pwmChannel, time - BIT_PULSE_TIME); // start of pulse for next low bit - falling edge on bus will not trigger cap interrupt
 		}
 		else
 		{
@@ -1217,7 +1217,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 			state = Bus::SEND_END_OF_TX;
 			time = BIT_TIME - BIT_PULSE_TIME;
 		}
-		timer.match(timeChannel, time - timer.value());
+		timer.match(timeChannel, time);
 		break;
 
 		//state is in sync with resp. to bus timing,  entered by match interrupt after last bytes stop bit was send

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -501,9 +501,10 @@ void Bus::handleTelegram(bool valid)
 	else if (nextByteIndex == 1 && parity)   // Received a spike or a bus acknowledgment, only parity, no checksum
 	{
 		tb_h( 907, currentByte, tb_in);
-		if ((currentByte == SB_BUS_ACK) && ((rx_error & RX_CHECKSUM_ERROR) == RX_CHECKSUM_ERROR))
+		if (((rx_error & RX_CHECKSUM_ERROR) == RX_CHECKSUM_ERROR) &&
+			((currentByte == SB_BUS_ACK) || (currentByte == SB_BUS_NACK) || (currentByte == SB_BUS_BUSY) || (currentByte == SB_BUS_NACK_BUSY)))
         {
-            // received a ACK so clear checksum bit previously set in Isr Bus::timerInterruptHandler
+            // received an ACK frame so clear checksum bit previously set in Isr Bus::timerInterruptHandler
             rx_error &= ~RX_CHECKSUM_ERROR;
         }
 


### PR DESCRIPTION
Up to now, the `Bus` class only detected that there was a collision on the bus, and even that not in every case. Then, it stopped sending and let the reception of the frame fail. Improve this in several ways:

1. Run collision detection whenever we're sending high data+parity bits (i.e. for all and not just for some of them)
2. When we detect a collision, switch to RX in a way that allows us to receive and process the collided frame, including correct checksum
3. Ensure repeated telegrams have lower risk of collision by following the KNX spec and sending them after 50 bit time instead of 76 bit time