### PR TITLE
Ensure telegrams are repeated if necessary

### DIFF
--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -331,7 +331,6 @@ private:
    // bool need_to_send_ack_to_remote; //!< receiving process need to send ack to remote sending side
     bool busy_wait_from_remote; //!< remote side is busy, re-send telegram after 150bit time wait
    // bool busy_wait_to_remote; //!< receiving process/ upper layer busy, send busy to remote sender
-    bool repeated;              //!< A send telegram is repeated
     bool repeatTelegram;        //!< need to repeat last  telegram sent
     bool collision;             //!< A collision occurred
     unsigned int lastRXTimeVal; //!< time measurement between telegrams - last SysTime value

--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -254,12 +254,16 @@ private:
     void idleState();
 
     /**
+     * Initializes all class variables to prepare for the next transmission.
+     */
+    void prepareForSending();
+
+    /**
      * Switch to the next telegram for sending.
      *
      * mark the current send buffer as free -> set first byte of buffer to 0
      * load a possible waiting/next buffer to current buffer
      * initialize some low level parameters for the interrupt driven send process
-     *
      */
     void sendNextTelegram();
 

--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -377,7 +377,7 @@ private:
 //
 inline bool Bus::idle() const
 {
-    return ((state == IDLE) || (state == INIT)) && (sendCurTelegram == 0);
+    return ((state == IDLE) || (state == INIT)) && (sendCurTelegram == nullptr);
 }
 
 inline void Bus::maxSendTries(int tries)
@@ -392,7 +392,7 @@ inline void Bus::maxSendBusyTries(int tries)
 
 inline bool Bus::sendingTelegram() const
 {
-    return sendCurTelegram != 0;
+    return sendCurTelegram != nullptr;
 }
 
 inline bool Bus::telegramReceived() const

--- a/sblib/inc/sblib/eib/bus_debug.h
+++ b/sblib/inc/sblib/eib/bus_debug.h
@@ -56,6 +56,7 @@
     extern volatile unsigned int telTXStartTime; //!< time when the transmission (start bit of first byte)of a telegram to the bus started
     extern volatile unsigned int telRXEndTime; //!< time when the reception  (last stop bit) of a telegram from bus ended
     extern volatile unsigned int telTXEndTime; //!< time when the transmission (last stop bit)of a telegram to the bus ended
+    extern volatile bool telRXNotProcessed; //!< received telegram was not processed as it does not affect us
     extern volatile unsigned int telTXAck; //!< ack send by L2
     extern volatile unsigned int telRXWaitInitTime; //!< Wait for 50 bit time after last RX/TX telegram, could be less- rx will be ignored
     extern volatile unsigned int telRXWaitIdleTime; //!< bus is in idle after 50 bit times, now wait for next start of RX/TX

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -442,7 +442,7 @@ void Bus::handleTelegram(bool valid)
 		}
 		else
 		{
-            DB_BUS(serial.println(" Bus::handleTelegram not processed: 0x", destAddr, HEX));
+            DB_BUS(telRXNotProcessed = true);
 		}
 
 		// Only process the telegram if it is for us or if we want to get all telegrams

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -171,8 +171,8 @@ void Bus::begin()
 	telegramLen = 0;
 	sendAck = 0;
 	//need_to_send_ack_to_remote=false;
-	sendCurTelegram = 0;
-	sendNextTel = 0;
+	sendCurTelegram = nullptr;
+	sendNextTel = nullptr;
 	collision = false;
 	state = Bus::INIT;  // we wait bus idle time (50 bit times) before setting bus to idle
 	//initialize bus-timer( e.g. defined as 16bit timer1)
@@ -578,7 +578,7 @@ void Bus::sendNextTelegram()
         sendCurTelegram[0] = 0;
     }
     sendCurTelegram = sendNextTel;
-    sendNextTel = 0;
+    sendNextTel = nullptr;
     sendTries = 0;
     sendBusyTries = 0;
     sendTelegramLen = 0;
@@ -935,7 +935,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 			else  // Send nothing:  wait PRE_SEND_TIME before we set the bus to idle state
 			{
 			    DB_BUS(
-				   if (sendCurTelegram != 0)
+				   if (sendCurTelegram != nullptr)
 				   {
 				       tb_h( state+ 900,sendCurTelegram[0], tb_in);
 				   }

--- a/sblib/src/eib/bus_debug.cpp
+++ b/sblib/src/eib/bus_debug.cpp
@@ -49,6 +49,9 @@
     volatile unsigned int telRXTelBitTimingErrorLate = 0;
     volatile unsigned int telRXTelBitTimingErrorEarly = 0;
     //volatile unsigned int db_state= 2000;
+
+    unsigned int telLastRXEndTime = 0;
+    unsigned int telLastTXEndTime = 0;
 #   define DB_TELEGRAM(x) x
 #else
 #   define DB_TELEGRAM(x)
@@ -70,59 +73,15 @@
 
 
 #ifdef DUMP_TELEGRAMS
+void dumpTXTelegram();
+void dumpRXTelegram();
+
 void dumpTelegrams()
 {
-    static unsigned int telLastRXEndTime = 0;
-    static unsigned int telLastTXEndTime = 0;
-
-    if (telTXAck)
+    // we transmitted a telegram before we received one
+    if (telTXEndTime && telTXEndTime < telRXEndTime)
     {
-        serial.println("TXAck:", telTXAck, HEX, 2);
-        telTXAck = 0;
-    }
-
-    //dump transmitting part
-    if (telTXEndTime) // we transmitted a telegram
-    {
-        serial.print("TX : (S", telTXStartTime, DEC, 6);
-        serial.print(" E", telTXEndTime, DEC, 6);
-
-        if (telLastRXEndTime)
-        {
-            // print time in between last rx-tel and current tx-tel
-            serial.print(" dt RX-TX:", (telTXStartTime - telLastRXEndTime), DEC, 8);
-            telLastRXEndTime = 0;
-        }
-        else if(telLastTXEndTime)
-        {
-            // print time in between last tx-tel and current tx-tel
-            serial.print(" dt TX-TX:", (telTXStartTime - telLastTXEndTime), DEC, 8);
-            telLastTXEndTime = 0;
-        }
-
-        if (tx_telrxerror != 0)
-        {
-            serial.print(" err: 0x", tx_telrxerror, HEX, 4);
-        }
-        else
-        {
-            serial.print("  ok: 0x", tx_telrxerror, HEX, 4);
-        }
-        serial.print(" rep:", tx_rep_count, DEC, 1);
-        serial.print(" brep:", tx_busy_rep_count, DEC, 1);
-        serial.print(") ");
-
-        //dump tx telegram data
-        for (unsigned int i = 0; i < txtelLength; ++i)
-        {
-            if (i) serial.print(" ");
-            serial.print(txtelBuffer[i], HEX, 2);
-        }
-        serial.println();
-
-        telLastTXEndTime = telTXEndTime;
-        telTXEndTime = 0;
-        telTXStartTime = 0;
+        dumpTXTelegram();
     }
 
 /*
@@ -188,79 +147,139 @@ void dumpTelegrams()
     //dump tel receiving part
     if (telLength > 0)
     {
-        serial.print("RX : (S", telRXStartTime, DEC, 6 );
-        serial.print(" E", telRXEndTime, DEC, 6);
-        /*
-        serial.print(") ");
-        serial.print(", LRXE:", telLastRXEndTime, DEC, 9);
-        serial.print(", LTXE:", telLastTXEndTime, DEC,9);
-        serial.print(") ");
-        */
-        if (telLastTXEndTime)
-        {
-            // print time in between last tx-tel and current rx-tel
-            serial.print(" dt TX-RX:", (telRXStartTime - telLastTXEndTime), DEC, 8);
-            telLastTXEndTime = 0;
-        }
-        else if(telLastRXEndTime)
-        {
-            // print time in between last rx-tel and current rx-tel
-            serial.print(" dt RX-RX:", (telRXStartTime - telLastRXEndTime), DEC, 8);
-            //serial.println(") ");
-            //telLastRXEndTime = 0;
-        }
-
-        if (telrxerror != 0)
-        {
-            serial.print(" err: 0x", telrxerror, HEX, 4);
-        }
-        else
-        {
-            serial.print("  ok: 0x", telrxerror, HEX, 4);
-        }
-        serial.print(") ");
-
-        if (telcollision)
-        {
-            serial.print("collision ");
-        }
-
-        //dump tel data
-        if (telLength > 1)
-        {
-            for (unsigned int i = 0; i < telLength; ++i)
-            {
-                if (i) serial.print(" ");
-                serial.print(telBuffer[i], HEX, 2);
-            }
-        }
-        else if (telLength == 1)
-        {
-            // maybe a LL_ACK, LL_NACK or LL_BUSY, try to decode it
-            switch (telBuffer[0])
-            {
-            case 0xcc :
-                serial.print("LL_ACK");
-                break;
-            case 0x0c :
-                serial.print("LL_NACK");
-                break;
-            case 0xc0 :
-                serial.print("LL_BUSY");
-                break;
-            default:
-                serial.print(telBuffer[0], HEX, 2);
-            }
-        }
-        serial.println();
-
-        //reset all debug data
-        telLength = 0;
-        telLastRXEndTime = telRXEndTime;
-        telRXEndTime = 0;
-        telrxerror = 0;
-        telRXTelByteStartTime = 0;
+        dumpRXTelegram();
     }
+
+    if (telTXAck)
+    {
+        serial.println("TXAck:", telTXAck, HEX, 2);
+        telTXAck = 0;
+    }
+
+    // we transmitted a telegram after receiving one
+    if (telTXEndTime)
+    {
+        dumpTXTelegram();
+    }
+}
+
+void dumpTXTelegram()
+{
+    serial.print("TX : (S", telTXStartTime, DEC, 6);
+    serial.print(" E", telTXEndTime, DEC, 6);
+
+    if (telLastRXEndTime)
+    {
+        // print time in between last rx-tel and current tx-tel
+        serial.print(" dt RX-TX:", (telTXStartTime - telLastRXEndTime), DEC, 8);
+        telLastRXEndTime = 0;
+    }
+    else if(telLastTXEndTime)
+    {
+        // print time in between last tx-tel and current tx-tel
+        serial.print(" dt TX-TX:", (telTXStartTime - telLastTXEndTime), DEC, 8);
+        telLastTXEndTime = 0;
+    }
+
+    if (tx_telrxerror != 0)
+    {
+        serial.print(" err: 0x", tx_telrxerror, HEX, 4);
+    }
+    else
+    {
+        serial.print("  ok: 0x", tx_telrxerror, HEX, 4);
+    }
+    serial.print(" rep:", tx_rep_count, DEC, 1);
+    serial.print(" brep:", tx_busy_rep_count, DEC, 1);
+    serial.print(") ");
+
+    //dump tx telegram data
+    for (unsigned int i = 0; i < txtelLength; ++i)
+    {
+        if (i) serial.print(" ");
+        serial.print(txtelBuffer[i], HEX, 2);
+    }
+    serial.println();
+
+    telLastTXEndTime = telTXEndTime;
+    telTXEndTime = 0;
+    telTXStartTime = 0;
+}
+
+void dumpRXTelegram()
+{
+    serial.print("RX : (S", telRXStartTime, DEC, 6 );
+    serial.print(" E", telRXEndTime, DEC, 6);
+    /*
+    serial.print(") ");
+    serial.print(", LRXE:", telLastRXEndTime, DEC, 9);
+    serial.print(", LTXE:", telLastTXEndTime, DEC,9);
+    serial.print(") ");
+    */
+    if (telLastTXEndTime)
+    {
+        // print time in between last tx-tel and current rx-tel
+        serial.print(" dt TX-RX:", (telRXStartTime - telLastTXEndTime), DEC, 8);
+        telLastTXEndTime = 0;
+    }
+    else if(telLastRXEndTime)
+    {
+        // print time in between last rx-tel and current rx-tel
+        serial.print(" dt RX-RX:", (telRXStartTime - telLastRXEndTime), DEC, 8);
+        //serial.println(") ");
+        //telLastRXEndTime = 0;
+    }
+
+    if (telrxerror != 0)
+    {
+        serial.print(" err: 0x", telrxerror, HEX, 4);
+    }
+    else
+    {
+        serial.print("  ok: 0x", telrxerror, HEX, 4);
+    }
+    serial.print(") ");
+
+    if (telcollision)
+    {
+        serial.print("collision ");
+    }
+
+    //dump tel data
+    if (telLength > 1)
+    {
+        for (unsigned int i = 0; i < telLength; ++i)
+        {
+            if (i) serial.print(" ");
+            serial.print(telBuffer[i], HEX, 2);
+        }
+    }
+    else if (telLength == 1)
+    {
+        // maybe a LL_ACK, LL_NACK or LL_BUSY, try to decode it
+        switch (telBuffer[0])
+        {
+        case 0xcc :
+            serial.print("LL_ACK");
+            break;
+        case 0x0c :
+            serial.print("LL_NACK");
+            break;
+        case 0xc0 :
+            serial.print("LL_BUSY");
+            break;
+        default:
+            serial.print(telBuffer[0], HEX, 2);
+        }
+    }
+    serial.println();
+
+    //reset all debug data
+    telLength = 0;
+    telLastRXEndTime = telRXEndTime;
+    telRXEndTime = 0;
+    telrxerror = 0;
+    telRXTelByteStartTime = 0;
 }
 #endif
 

--- a/sblib/src/eib/bus_debug.cpp
+++ b/sblib/src/eib/bus_debug.cpp
@@ -41,6 +41,7 @@
     volatile unsigned int telTXStartTime = 0;
     volatile unsigned int telRXEndTime = 0;
     volatile unsigned int telTXEndTime = 0;
+    volatile bool telRXNotProcessed = false;
     volatile unsigned int telTXAck = 0;
     volatile unsigned int telRXWaitInitTime = 0;
     volatile unsigned int telRXWaitIdleTime = 0;
@@ -245,6 +246,11 @@ void dumpRXTelegram()
         serial.print("collision ");
     }
 
+    if (telRXNotProcessed)
+    {
+        serial.print("not processed ");
+    }
+
     //dump tel data
     if (telLength > 1)
     {
@@ -280,6 +286,7 @@ void dumpRXTelegram()
     telRXEndTime = 0;
     telrxerror = 0;
     telRXTelByteStartTime = 0;
+    telRXNotProcessed = false;
 }
 #endif
 


### PR DESCRIPTION
After sending out a telegram, we wait for an acknowledge frame. Previously, when we did not receive an ACK but a real telegram, we did not repeat the telegram anymore.

With this fix, receiving another unrelated telegram does not clear the `repeatTelegram` flag anymore. Also, only the first acknowledge frame we receive within the allotted time window is evaluated. Consecutive ACKs or ACKs sent in response to other telegrams do not prevent our repetition anymore.