### PR TITLE
Fix TL4 not responsible for repeated check 

### DIFF
--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderStatistic.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderStatistic.java
@@ -4,23 +4,23 @@ import org.selfbus.updater.Utils;
 
 public class BootloaderStatistic {
     private final int disconnectCount;
-    private final int repeatedIgnoredTelegramCount;
+    private final int reserved;
 
 
-    public BootloaderStatistic(int disconnectCount, int repeatedIgnoredTelegramCount) {
+    public BootloaderStatistic(int disconnectCount, int reserved) {
         this.disconnectCount = disconnectCount;
-        this.repeatedIgnoredTelegramCount = repeatedIgnoredTelegramCount;
+        this.reserved = reserved;
     }
 
     public static BootloaderStatistic fromArray(byte[] parse) {
         int disConnectCount = Utils.streamToShort(parse, 0);
-        int repeatedIgnoredTelegramCount = Utils.streamToShort(parse, 2);
-        return new BootloaderStatistic(disConnectCount, repeatedIgnoredTelegramCount);
+        int reserved = Utils.streamToShort(parse, 2);
+        return new BootloaderStatistic(disConnectCount, reserved);
     }
 
     public String toString() {
-        return String.format("#Disconnect: %d #Repeated ignored: %d",
-                              getDisconnectCount(), getRepeatedIgnoredTelegramCount());
+        return String.format("#Disconnect: %d",
+                              getDisconnectCount());
     }
 
     public long getDisconnectCount()
@@ -28,8 +28,8 @@ public class BootloaderStatistic {
         return disconnectCount;
     }
 
-    public long getRepeatedIgnoredTelegramCount()
+    public long getReserved()
     {
-        return repeatedIgnoredTelegramCount;
+        return reserved;
     }
 }

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderStatistic.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderStatistic.java
@@ -4,23 +4,23 @@ import org.selfbus.updater.Utils;
 
 public class BootloaderStatistic {
     private final int disconnectCount;
-    private final int reserved;
+    private final int ignoredNdataIndividual;
 
 
-    public BootloaderStatistic(int disconnectCount, int reserved) {
+    public BootloaderStatistic(int disconnectCount, int ignoredNdataIndividual) {
         this.disconnectCount = disconnectCount;
-        this.reserved = reserved;
+        this.ignoredNdataIndividual = ignoredNdataIndividual;
     }
 
     public static BootloaderStatistic fromArray(byte[] parse) {
         int disConnectCount = Utils.streamToShort(parse, 0);
-        int reserved = Utils.streamToShort(parse, 2);
-        return new BootloaderStatistic(disConnectCount, reserved);
+        int ignoredNdataIndividual = Utils.streamToShort(parse, 2);
+        return new BootloaderStatistic(disConnectCount, ignoredNdataIndividual);
     }
 
     public String toString() {
-        return String.format("#Disconnect: %d",
-                              getDisconnectCount());
+        return String.format("#Disconnect: %d #Ignored N_DATA_INDIVIDUAL: %d",
+                              getDisconnectCount(), getIgnoredNdataIndividual());
     }
 
     public long getDisconnectCount()
@@ -28,8 +28,8 @@ public class BootloaderStatistic {
         return disconnectCount;
     }
 
-    public long getReserved()
+    public long getIgnoredNdataIndividual()
     {
-        return reserved;
+        return ignoredNdataIndividual;
     }
 }

--- a/Bus-Updater/src/bcu_updater.cpp
+++ b/Bus-Updater/src/bcu_updater.cpp
@@ -78,13 +78,8 @@ unsigned char BcuUpdate::processApci(ApciCommand apciCmd, const uint16_t senderA
             d3(
                 serial.println();serial.println();serial.println();
                 serial.println("disconnectCount ", disconnectCount);
-
-                ///\todo remove after fix and on release
-                serial.println("ignored  ", repeatedIgnoredTelegramCount);
-                ///\todo end of remove after fix and on release
-
                 serial.println();serial.println();serial.println();
-                serial.flush();  // give time to send serial data
+                serial.flush(); // give time to send serial data
             );
             endDelay = millis() + RESET_DELAY_MS;
             while (millis() < endDelay)

--- a/Bus-Updater/src/bcu_updater.cpp
+++ b/Bus-Updater/src/bcu_updater.cpp
@@ -77,7 +77,8 @@ unsigned char BcuUpdate::processApci(ApciCommand apciCmd, const uint16_t senderA
             dump2(serial.println("APCI_BASIC_RESTART_PDU"));
             d3(
                 serial.println();serial.println();serial.println();
-                serial.println("disconnectCount ", disconnectCount);
+                serial.println("disconnectCount           ", disconnectCount);
+                serial.println("ignored N_DATA_INDIVIDUAL ", ignoredNdataIndividual);
                 serial.println();serial.println();serial.println();
                 serial.flush(); // give time to send serial data
             );

--- a/Bus-Updater/src/update.cpp
+++ b/Bus-Updater/src/update.cpp
@@ -558,13 +558,13 @@ static unsigned char updRequestBootloaderIdentity(uint8_t * data)
  */
 static unsigned char updRequestStatistic()
 {
-    uint32_t sizeTotal = sizeof(disconnectCount) + sizeof(repeatedIgnoredTelegramCount);
+    uint16_t reserved = 0;
+    uint32_t sizeTotal = sizeof(disconnectCount) + sizeof(reserved);
 
     prepareReturnTelegram(bcu.sendTelegram, sizeTotal, UPD_RESPONSE_STATISTIC);
     uShort16ToStream(bcu.sendTelegram + 9, disconnectCount);
-    uShort16ToStream(bcu.sendTelegram + 9 + sizeof(disconnectCount), repeatedIgnoredTelegramCount);
+    uShort16ToStream(bcu.sendTelegram + 9 + sizeof(disconnectCount), reserved);
     d3(serial.print(" #DC ", disconnectCount));
-    d3(serial.print(" #ignor ", repeatedIgnoredTelegramCount));
     return (T_ACK_PDU);
 }
 

--- a/Bus-Updater/src/update.cpp
+++ b/Bus-Updater/src/update.cpp
@@ -558,13 +558,13 @@ static unsigned char updRequestBootloaderIdentity(uint8_t * data)
  */
 static unsigned char updRequestStatistic()
 {
-    uint16_t reserved = 0;
-    uint32_t sizeTotal = sizeof(disconnectCount) + sizeof(reserved);
+    uint32_t sizeTotal = sizeof(disconnectCount) + sizeof(ignoredNdataIndividual);
 
     prepareReturnTelegram(bcu.sendTelegram, sizeTotal, UPD_RESPONSE_STATISTIC);
     uShort16ToStream(bcu.sendTelegram + 9, disconnectCount);
-    uShort16ToStream(bcu.sendTelegram + 9 + sizeof(disconnectCount), reserved);
+    uShort16ToStream(bcu.sendTelegram + 9 + sizeof(disconnectCount), ignoredNdataIndividual);
     d3(serial.print(" #DC ", disconnectCount));
+    d3(serial.print(" #ignor ", ignoredNdataIndividual));
     return (T_ACK_PDU);
 }
 

--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -336,7 +336,6 @@ private:
    // bool busy_wait_to_remote; //!< receiving process/ upper layer busy, send busy to remote sender
     bool repeatTelegram;        //!< need to repeat last  telegram sent
     bool collision;             //!< A collision occurred
-    unsigned int lastRXTimeVal; //!< time measurement between telegrams - last SysTime value
 };
 
 

--- a/sblib/inc/sblib/eib/knx_tlayer4.h
+++ b/sblib/inc/sblib/eib/knx_tlayer4.h
@@ -28,8 +28,15 @@
 
 
 #define TL4_CONNECTION_TIMEOUT_MS (6000) //!< Transport layer 4 connection timeout in milliseconds
-#define TL4_ACK_TIMEOUT_MS        (3000) //!< Transport layer 4 T_ACK/T_NACK timeout in milliseconds, not used in Style 1 Rationalised
+#define TL4_T_ACK_TIMEOUT_MS      (3000) //!< Transport layer 4 T_ACK/T_NACK timeout in milliseconds, not used in Style 1 Rationalised
 #define TL4_CTRL_TELEGRAM_SIZE    (8)    //!< The size of a connection control telegram
+
+/**
+ * The T_ACK suppression window in milliseconds for a repeated/duplicate N_DATA_INDIVIDUAL.
+ * @warning The T_ACK suppression in action A03 @ref actionA03sendAckPduAgain is NOT KNX Spec. 2.1 conform
+ */
+#define TL4_T_ACK_SUPPRESS_WINDOW_MS (TL4_T_ACK_TIMEOUT_MS/2)
+
 
 #ifdef DEBUG
 #   define LONG_PAUSE_THRESHOLD_MS (500)
@@ -224,6 +231,8 @@ private:
      *          connection.
      *          <p>
      *          Prevent this by staying silent and intentionally disobeying the spec.
+     *          <p>
+     *          The T_ACK suppression is NOT KNX Spec. 2.1 conform
      */
     void actionA03sendAckPduAgain(const int8_t seqNo);
 

--- a/sblib/inc/sblib/eib/knx_tlayer4.h
+++ b/sblib/inc/sblib/eib/knx_tlayer4.h
@@ -38,10 +38,6 @@
 extern uint16_t telegramCount;   //!< number of telegrams since system reset
 extern uint16_t disconnectCount; //!< number of disconnects since system reset
 
-///\todo remove after bugfix and on release
-extern uint16_t repeatedIgnoredTelegramCount;
-///\todo end of remove after bugfix and on release
-
 /**
  * Implementation of the KNX transportation layer 4 Style 1 Rationalised
  */
@@ -251,18 +247,6 @@ private:
     int8_t seqNoRcv = -1;                       //!< Sequence number of the last telegram received from connected partner
     bool telegramReadyToSend = false;           //!< True if a response is ready to be sent after our @ref T_ACK is confirmed
     uint32_t connectedTime = 0;                 //!< System time of the last connection oriented telegram
-
-    bool checkValidRepeatedTelegram(unsigned char *telegram, uint8_t telLength);  ///\todo remove after fix in Bus and on release
-
-    /**
-     * Copies currently processed telegram to @ref lastTelegram
-     * @param telegram  Current telegram processed
-     * @param telLength Length of current telegram
-     */
-    void copyTelegram(unsigned char *telegram, uint8_t telLength);
-
-    byte *lastTelegram;  //!< Buffer to store the last telegram received to compare with telegram currently processed
-    uint8_t lastTelegramLength = 0;         //!< Length of the last Telegram received
 
     volatile uint16_t ownAddr;                 //!< Our own physical address on the bus
 };

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -453,10 +453,9 @@ void Bus::handleTelegram(bool valid)
 				}
 		}
 		if (processTel)
-		{// check for repeated telegram, did we already received it -check that time between telegram is about 50bit times
+		{// check for repeated telegram, did we already received it
 			// check the repeat bit in header and compare with previous received telegram still stored in the telegram[] buffer
 			bool already_received = false;
-			//check time in between the telegrams received should be less than 6ms for repeated tel and the orig tel
 			if (!(rx_telegram[0] & SB_TEL_REPEAT_FLAG)) // a repeated tel
 			{// compare telegrams
 				if ((rx_telegram[0] & ~SB_TEL_REPEAT_FLAG) == (telegram[0] & ~SB_TEL_REPEAT_FLAG))

--- a/sblib/src/eib/knx_tlayer4.cpp
+++ b/sblib/src/eib/knx_tlayer4.cpp
@@ -635,8 +635,8 @@ void TLayer4::processDirectTelegram(ApciCommand apciCmd, unsigned char *telegram
         // event E05
         dump2(
             serial.print("EVENT 5 seqNo ", seqNo);
-            serial.print(" != ", (seqNoRcv-1) & 0x0F);
-            serial.print(" seqNoRcv-1");
+            serial.print(" == ", (seqNoRcv-1) & 0x0F);
+            serial.print(" (seqNoRcv-1)");
             serial.print(LOG_SEP);
             dumpTelegramBytes(false, telegram, telLength);
         );

--- a/test/lib-test-cases/src/tc_tlayer4_telegram.h
+++ b/test/lib-test-cases/src/tc_tlayer4_telegram.h
@@ -229,7 +229,25 @@ static Telegram testCaseTelegrams_20b[] =
 
 static Telegram testCaseTelegrams_21[] =
 {
-    // KNX Spec. 8/3/4 2.3.3.1 p.30
+    // see TLayer4::actionA03sendAckPduAgain(..) why we don't follow the KNX Spec 2.1 in this test
+    // Step 3 modified and not compliant with KNX Spec. 8/3/4 2.3.3.1 p.30
+
+    // 1. T_CONNECT_PDU (0x80) from sourceAddr=10.15.254 to destAddr=1.0.1
+    {TEL_RX, 7, 0, 0x1001, connect, {0xB0, 0xAF, 0xFE, 0x10, 0x01, 0x60, 0x80}},
+    // 2. DeviceDescriptorRead(DescType=00) from sourceAddr=10.15.254 to destAddr=1.0.1
+    {TEL_RX, 8, 0, 0, NULL, {0xB0, 0xAF, 0xFE, 0x10, 0x01, 0x61, 0x7F, 0x00}},
+    // 3. Check for empty TX-Response
+    {CHECK_TX_BUFFER, 0, 0, 0, connectedOpenIdle, {}},
+    // 4. simulate 6000 milliseconds passing, loop bcu once
+    {TIMER_TICK,  6000, 1, 0, NULL, {}},
+    // 5. Check TX-Response for a T_DISCONNECT_PDU (0x81) to 10.0.1
+    {TEL_TX, 7, 0, 0, disconnectClosed, {0xB0, 0x10, 0x01, 0xAF, 0xFE, 0x60, 0x81}},
+    // 6. Check for empty TX-Response
+    {CHECK_TX_BUFFER, 0, 0, 0, NULL, {}},
+    {END}
+
+    /*
+    // specified in KNX Spec. 8/3/4 2.3.3.1 p.30
     // 1. T_CONNECT_PDU (0x80) from sourceAddr=10.15.254 to destAddr=1.0.1
     {TEL_RX, 7, 0, 0x1001, connect, {0xB0, 0xAF, 0xFE, 0x10, 0x01, 0x60, 0x80}},
     // 2. DeviceDescriptorRead(DescType=00) from sourceAddr=10.15.254 to destAddr=1.0.1
@@ -243,11 +261,14 @@ static Telegram testCaseTelegrams_21[] =
     // 6. Check for empty TX-Response
     {CHECK_TX_BUFFER, 0, 0, 0, NULL, {}},
     {END}
+    */
 };
 
 static Telegram testCaseTelegrams_22[] =
 {
-    // KNX Spec. 8/3/4 2.3.3.2 p.31
+    // see TLayer4::actionA03sendAckPduAgain(..) why we don't follow the KNX Spec 2.1 in this test
+    // Step 5 modified and not compliant with KNX Spec. 8/3/4 2.3.3.2 p.31
+
     // 0. T_CONNECT_PDU (0x80) from sourceAddr=10.0.1 to destAddr=10.0.0
     // 0.1 simulate a T_DATA_CONNECTED from sourceAddr=10.0.1 to destAddr=10.0.0
     // steps 0.x done in tc_setup_OpenWait_A001
@@ -256,16 +277,32 @@ static Telegram testCaseTelegrams_22[] =
     {TEL_RX,  8, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x01, 0xA0, 0x00, 0x61, 0x43, 0x00}},
     // 2. Check T_ACK response for the DeviceDescriptorRead
     {TEL_TX,  7, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x00, 0xA0, 0x01, 0x60, 0xC2}}, // T_ACK_PDU Seq=0
-    // 3. repeated DeviceDescriptorRead(DescType=00) from sourceAddr=10.0.1 to destAddr=10.0.0
-    {TEL_RX,  8, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x01, 0xA0, 0x00, 0x61, 0x43, 0x00}},
-
-    ///\todo not sure if this is correct, test sequence 22 repeated T_DATA_CONNECTED
-    // 4. Read the DeviceDescriptorRead response
+    // 3. Check the DeviceDescriptorRead Response
     {TEL_TX, 10, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x00, 0xA0, 0x01, 0x63, 0x43, 0x40, dummyMaskVersionHigh, dummyMaskVersionLow}},
+    // 4. repeated DeviceDescriptorRead(DescType=00) from sourceAddr=10.0.1 to destAddr=10.0.0
+    {TEL_RX,  8, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x01, 0xA0, 0x00, 0x61, 0x43, 0x00}},
+    // 5. Check for empty TX-Response
+    {CHECK_TX_BUFFER, 0, 0, 0, connectedOpenWait, {}},
+    {END}
 
-    // 5. Check T_ACK response for the DeviceDescriptorRead
+    /*
+    // specified in KNX Spec. 8/3/4 2.3.3.2 p.31
+    // 0. T_CONNECT_PDU (0x80) from sourceAddr=10.0.1 to destAddr=10.0.0
+    // 0.1 simulate a T_DATA_CONNECTED from sourceAddr=10.0.1 to destAddr=10.0.0
+    // steps 0.x done in tc_setup_OpenWait_A001
+
+    // 1. DeviceDescriptorRead(DescType=00) from sourceAddr=10.0.1 to destAddr=10.0.0
+    {TEL_RX,  8, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x01, 0xA0, 0x00, 0x61, 0x43, 0x00}},
+    // 2. Check T_ACK response for the DeviceDescriptorRead
+    {TEL_TX,  7, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x00, 0xA0, 0x01, 0x60, 0xC2}}, // T_ACK_PDU Seq=0
+    // 3. Check the DeviceDescriptorRead Response
+    {TEL_TX, 10, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x00, 0xA0, 0x01, 0x63, 0x43, 0x40, dummyMaskVersionHigh, dummyMaskVersionLow}},
+    // 4. repeated DeviceDescriptorRead(DescType=00) from sourceAddr=10.0.1 to destAddr=10.0.0
+    {TEL_RX,  8, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x01, 0xA0, 0x00, 0x61, 0x43, 0x00}},
+    // 5. Check T_ACK response for the second DeviceDescriptorRead
     {TEL_TX,  7, 0, 0xA001, connectedOpenWait, {0xB0, 0xA0, 0x00, 0xA0, 0x01, 0x60, 0xC2}}, // T_ACK_PDU Seq=0
     {END}
+    */
 };
 
 static Telegram testCaseTelegrams_23[] =


### PR DESCRIPTION
Transport layer 4 is not responsible to check for repeated telegrams