### PR TITLE
Do not disable interrupts anymore when starting to send

### DIFF
--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -248,7 +248,12 @@ public:
 
 private:
     /**
-     * Switch to idle state
+     * Switch to @ref Bus::IDLE state
+     * @details Set the Bus state machine to @ref Bus::IDLE state.
+     *          We waited at least 50 Bit times (without cap event enabled),
+     *          now we wait for next Telegram to receive.
+     *          Configure the capture to falling edge and interrupt
+     *          match register for low PWM output
      */
     void idleState();
 

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -697,7 +697,7 @@ __attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
 
 		tv=timer.value(); cv= timer.capture(captureChannel);
 		if ( tv > cv ) dt= tv - cv; // check for timer overflow since cap event
-		else dt = (0xffff-cv) +tv;
+		else dt = (timer.match(timeChannel)-cv) +tv;
 		timer.restart();  // restart timer and pre-load with processing time of 2us
 		timer.value(dt+2);
 		timer.match(timeChannel, BYTE_TIME_INCL_STOP);


### PR DESCRIPTION
There is an ugly `noInterrupts()`/`interrupts()` pair in `Bus::sendTelegram`. It disables *all* interrupts while we're checking whether we're in the `IDLE` state and should start sending right away. After analyzing the situation and listing a few options, Approach 4 is implemented in this PR as it is the most reliable one.

# Starting point
```
    noInterrupts();
    if (state == IDLE)
    {
        ...
    }
    interrupts();
```
*Problem statement:* Can we do better, ideally without the `noInterrupts`/`interrupts` pair?


# Approach 1: Just disable the timer interrupt, not all interrupts
```
    timer.noInterrupts();
    if (state == IDLE)
    {
        ...
    }
    timer.interrupts();
```
Improves matters. Still, in the time span with disabled interrupts there's no way to detect falling edges (start bits) on the capture channel pin. Thus, we might miss a full telegram.


# Approach 2: Just disable the timer interrupt, not all interrupts, and only in state `Bus::IDLE`
```
    if (state == IDLE)
    {
        timer.noInterrupts();
        if (state == IDLE)
        {
            ...
        }
        timer.interrupts();
    }
```
Improves matters even more. This is called Double-Checked Locking. After the first `if` condition the timer ISR could have run and could have changed `state` before we got a chance to disable the interrupt. Again, in the time span with disabled interrupts there's no way to detect falling edges (start bits) on the capture channel pin. Thus we might miss a full telegram.


# Approach 3: Just disable the capture channel interrupt, not all interrupts, and only in state `Bus::IDLE`
```
    if (state == IDLE)
    {
        timer.captureMode(captureChannel, FALLING_EDGE);
        if (state == IDLE)
        {
            ...
        }
        timer.captureMode(captureChannel, FALLING_EDGE | INTERRUPT);
    }
```
As the capture channel is the only one to trigger the interrupt in state `IDLE`, this is just another variant of Approach 2.


# Approach 4: Do not disable interrupts at all

All interrupts remain enabled all the time and we can reliably detect falling edges (start bits). In order to make the switch from `IDLE`->`WAIT_50BT_FOR_NEXT_RX_OR_PENDING_TX_OR_IDLE` atomically, this part of the code moves to the ISR. Consequently, the timer must run all the time and check continuously whether there's anything to send.