### PR TITLE
Improve compliance with KNX spec

### DIFF
--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/DeviceManagement.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/DeviceManagement.java
@@ -339,12 +339,12 @@ public final class DeviceManagement {
             catch (KNXTimeoutException | KNXRemoteException e) {
                 logger.warn("{}{} {} : {}{}", ConColors.RED, command, e.getMessage(), e.getClass().getSimpleName(), ConColors.RESET);
                 result.incTimeoutCount();
-                Thread.sleep(TL4_CONNECTION_TIMEOUT_MS);
+                //Thread.sleep(TL4_CONNECTION_TIMEOUT_MS); ///\todo remove on release
             }
             catch (KNXDisconnectException e) {
                 logger.warn("{}{} {} : {}{}", ConColors.RED, command, e.getMessage(), e.getClass().getSimpleName(), ConColors.RESET);
                 result.incDropCount();
-                Thread.sleep(TL4_CONNECTION_TIMEOUT_MS);
+                //Thread.sleep(TL4_CONNECTION_TIMEOUT_MS); ///\todo remove on release
             }
             catch (KNXIllegalArgumentException e) {
                 throw new UpdaterException(String.format("%s failed.", command), e);

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
@@ -241,7 +241,7 @@ public class Updater implements Runnable {
                 result.written(), flashTimeDuration, col, bytesPerSecond, ConColors.RESET);
 
         if (result.dropCount() > 0) {
-            infoMsg += String.format(" %Disconnects: %d%s", ConColors.BRIGHT_RED, result.dropCount(), ConColors.RESET);
+            infoMsg += String.format(" %sDisconnects: %d%s", ConColors.BRIGHT_RED, result.dropCount(), ConColors.RESET);
         } else {
             infoMsg += String.format(" %sDisconnect: %d%s", ConColors.BRIGHT_GREEN, result.dropCount(), ConColors.RESET);
         }

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
@@ -240,15 +240,15 @@ public class Updater implements Runnable {
         String infoMsg = String.format("Wrote %d bytes from file to device in %tM:%<tS. %s(%.2f B/s)%s",
                 result.written(), flashTimeDuration, col, bytesPerSecond, ConColors.RESET);
 
+        if (result.dropCount() > 0) {
+            infoMsg += String.format(" %Disconnects: %d%s", ConColors.BRIGHT_RED, result.dropCount(), ConColors.RESET);
+        } else {
+            infoMsg += String.format(" %sDisconnect: %d%s", ConColors.BRIGHT_GREEN, result.dropCount(), ConColors.RESET);
+        }
         if (result.timeoutCount() > 0) {
-            infoMsg += String.format(" %sTimeout(s): %d%s", ConColors.BRIGHT_RED, result.timeoutCount(), ConColors.RESET);
+            infoMsg += String.format(" %sTimeouts: %d%s", ConColors.BRIGHT_RED, result.timeoutCount(), ConColors.RESET);
         } else {
             infoMsg += String.format(" %sTimeout: %d%s", ConColors.BRIGHT_GREEN, result.timeoutCount(), ConColors.RESET);
-        }
-        if (result.dropCount() > 0) {
-            infoMsg += String.format(" %sDrop(s): %d%s", ConColors.BRIGHT_RED, result.dropCount(), ConColors.RESET);
-        } else {
-            infoMsg += String.format(" %sDrop: %d%s", ConColors.BRIGHT_GREEN, result.dropCount(), ConColors.RESET);
         }
         logger.info("{}", infoMsg);
     }
@@ -259,7 +259,7 @@ public class Updater implements Runnable {
     public static final IndividualAddress PHYS_ADDRESS_BOOTLOADER = new IndividualAddress(15, 15,192); //!< physical address the bootloader is using
     public static final IndividualAddress PHYS_ADDRESS_OWN = new IndividualAddress(0, 0,0); //!< physical address the Selfbus Updater is using
 
-    public static final int RESPONSE_TIMEOUT_SEC = 2; //!< Time in seconds the Updater shall wait for a KNX Response
+    public static final int RESPONSE_TIMEOUT_SEC = 3; //!< Time in seconds the Updater shall wait for a KNX Response
 
     /*
      * (non-Javadoc)

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootDescriptor.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootDescriptor.java
@@ -26,15 +26,12 @@ public class BootDescriptor {
      * @throws UpdaterException Exception in case of invalid start or end address
      */
     public BootDescriptor(long startAddress, long endAddress, int crc32, long appVersionAddress) throws UpdaterException {
-        if (startAddress > endAddress) {
-            throw new UpdaterException("startAddress beyond endAddress");
-        }
         this.startAddress = startAddress;
         this.endAddress = endAddress;
         this.crc32 = crc32;
         this.appVersionAddress = appVersionAddress;
 
-        valid = (this.startAddress != 0xFFFFFFFFL);
+        valid = (this.startAddress != 0xFFFFFFFFL) && (startAddress < endAddress);
     }
 
 

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderStatistic.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderStatistic.java
@@ -4,23 +4,23 @@ import org.selfbus.updater.Utils;
 
 public class BootloaderStatistic {
     private final int disconnectCount;
-    private final int ignoredNdataIndividual;
+    private final int repeatedT_ACKcount;
 
 
-    public BootloaderStatistic(int disconnectCount, int ignoredNdataIndividual) {
+    public BootloaderStatistic(int disconnectCount, int repeatedT_ACKcount) {
         this.disconnectCount = disconnectCount;
-        this.ignoredNdataIndividual = ignoredNdataIndividual;
+        this.repeatedT_ACKcount = repeatedT_ACKcount;
     }
 
     public static BootloaderStatistic fromArray(byte[] parse) {
         int disConnectCount = Utils.streamToShort(parse, 0);
-        int ignoredNdataIndividual = Utils.streamToShort(parse, 2);
-        return new BootloaderStatistic(disConnectCount, ignoredNdataIndividual);
+        int repeatedT_ACKcount = Utils.streamToShort(parse, 2);
+        return new BootloaderStatistic(disConnectCount, repeatedT_ACKcount);
     }
 
     public String toString() {
-        return String.format("#Disconnect: %d #Ignored N_DATA_INDIVIDUAL: %d",
-                              getDisconnectCount(), getIgnoredNdataIndividual());
+        return String.format("#Disconnect: %d #repeated T_ACK: %d",
+                              getDisconnectCount(), getRepeatedT_ACKcount());
     }
 
     public long getDisconnectCount()
@@ -28,8 +28,8 @@ public class BootloaderStatistic {
         return disconnectCount;
     }
 
-    public long getIgnoredNdataIndividual()
+    public long getRepeatedT_ACKcount()
     {
-        return ignoredNdataIndividual;
+        return repeatedT_ACKcount;
     }
 }

--- a/Bus-Updater/src/bcu_updater.cpp
+++ b/Bus-Updater/src/bcu_updater.cpp
@@ -77,8 +77,8 @@ unsigned char BcuUpdate::processApci(ApciCommand apciCmd, const uint16_t senderA
             dump2(serial.println("APCI_BASIC_RESTART_PDU"));
             d3(
                 serial.println();serial.println();serial.println();
-                serial.println("disconnectCount           ", disconnectCount);
-                serial.println("ignored N_DATA_INDIVIDUAL ", ignoredNdataIndividual);
+                serial.println("disconnectCount ", disconnectCount);
+                serial.println("repeated T_ACK  ", repeatedT_ACKcount);
                 serial.println();serial.println();serial.println();
                 serial.flush(); // give time to send serial data
             );

--- a/Bus-Updater/src/update.cpp
+++ b/Bus-Updater/src/update.cpp
@@ -558,13 +558,13 @@ static unsigned char updRequestBootloaderIdentity(uint8_t * data)
  */
 static unsigned char updRequestStatistic()
 {
-    uint32_t sizeTotal = sizeof(disconnectCount) + sizeof(ignoredNdataIndividual);
+    uint32_t sizeTotal = sizeof(disconnectCount) + sizeof(repeatedT_ACKcount);
 
     prepareReturnTelegram(bcu.sendTelegram, sizeTotal, UPD_RESPONSE_STATISTIC);
     uShort16ToStream(bcu.sendTelegram + 9, disconnectCount);
-    uShort16ToStream(bcu.sendTelegram + 9 + sizeof(disconnectCount), ignoredNdataIndividual);
+    uShort16ToStream(bcu.sendTelegram + 9 + sizeof(disconnectCount), repeatedT_ACKcount);
     d3(serial.print(" #DC ", disconnectCount));
-    d3(serial.print(" #ignor ", ignoredNdataIndividual));
+    d3(serial.print(" #repT_ACK ", repeatedT_ACKcount));
     return (T_ACK_PDU);
 }
 

--- a/sblib/inc/sblib/eib/knx_tlayer4.h
+++ b/sblib/inc/sblib/eib/knx_tlayer4.h
@@ -31,20 +31,13 @@
 #define TL4_T_ACK_TIMEOUT_MS      (3000) //!< Transport layer 4 T_ACK/T_NACK timeout in milliseconds, not used in Style 1 Rationalised
 #define TL4_CTRL_TELEGRAM_SIZE    (8)    //!< The size of a connection control telegram
 
-/**
- * The T_ACK suppression window in milliseconds for a repeated/duplicate N_DATA_INDIVIDUAL.
- * @warning The T_ACK suppression in action A03 @ref actionA03sendAckPduAgain is NOT KNX Spec. 2.1 conform
- */
-#define TL4_T_ACK_SUPPRESS_WINDOW_MS (TL4_T_ACK_TIMEOUT_MS/2)
-
-
 #ifdef DEBUG
 #   define LONG_PAUSE_THRESHOLD_MS (500)
 #endif
 
 extern uint16_t telegramCount;   //!< number of telegrams since system reset
 extern uint16_t disconnectCount; //!< number of disconnects since system reset
-extern uint16_t ignoredNdataIndividual; //!< number of N_DATA_INDIVIDUAL ignored in @ref actionA03sendAckPduAgain
+extern uint16_t repeatedT_ACKcount; //!< number of repeated @ref T_ACK_PDU in @ref actionA03sendAckPduAgain
 
 /**
  * Implementation of the KNX transportation layer 4 Style 1 Rationalised
@@ -219,20 +212,6 @@ private:
     /**
      * Performs action A3 as described in the KNX Spec. 2.1 3/3/4 5.3 p.19
      * @param seqNo Sequence number the T_ACK should be send with
-     *
-     * @warning The Data Link Layer filters out repeated telegrams, provided that the repetition follows
-     *          directly after the original telegram. If another telegram sneaks in (e.g. due to higher
-     *          priority), we encounter such repeated telegrams in the Transport Layer.
-     *          <p>
-     *          Per KNX Spec 2.1, Chapter 3/3/4 Section 5.4.4.3 p.27, this is Event E05 and its corresponding Action A3.
-     *          The spec says to send another T_ACK for such a repeated telegram, but here's the catch:
-     *          If the client does not implement Style 3, such as calimero-core 2.5.1 at the time of this writing (2023/04/02),
-     *          it will see a duplicate T_ACK in state OPEN_IDLE (events E08/E09) and consequently close the
-     *          connection.
-     *          <p>
-     *          Prevent this by staying silent and intentionally disobeying the spec.
-     *          <p>
-     *          The T_ACK suppression is NOT KNX Spec. 2.1 conform
      */
     void actionA03sendAckPduAgain(const int8_t seqNo);
 

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -438,7 +438,7 @@ void Bus::handleTelegram(bool valid)
 			processTel = true;
 		}
 
-        DB_BUS(telRXNotProcessed = !processTel);
+		DB_TELEGRAM(telRXNotProcessed = !processTel);
 
 		// Only process the telegram if it is for us or if we want to get all telegrams
 		if (!(bcu->userRam->status() & BCU_STATUS_TRANSPORT_LAYER))

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -472,15 +472,11 @@ void Bus::handleTelegram(bool valid)
 				//  check for space in rx buffer for next telegram, if no space available, send busy back
 				if (telegramLen)
 				{
-					sendAck = SB_BUS_BUSY;
-					if (destAddr == 0)
-					{
-					    // KNX Spec. 2.1. 3/2/2 2.4.1 p.38
-					    // Device should only send a LL_BUSY if it knows that the telegram can be processed within the next 100ms.
-					    // Since we know nothing about the running application we better stay quiet
-					    // don't send LL_BUSY for broadcasts
-					    sendAck = 0;
-					}
+				    // KNX Spec. 2.1. 3/2/2 2.4.1 p.38
+ 			        // Device should only send a LL_BUSY if it knows that the telegram can be processed within the next 100ms.
+					// Since we know nothing about the running application we better stay quiet
+					// don't send LL_BUSY for broadcasts
+					sendAck = 0;
 					rx_error |= RX_BUFFER_BUSY;
 				}
 				else


### PR DESCRIPTION
This PR contains the following changes:
1. PC Updater: Reconnect to device without any delay when the connection drops.
2. PC Updater: Response timeout is 3sec per the KNX spec.
3. sblib: Never send LL_BUSY acknowledge frames. Per the KNX spec, these should only be sent when a device is certain it'll be unable to process the telegram in the next 100ms, otherwise it should just stay silent (and wait for the repeated telegram).
4. sblib: In connection-oriented communication, always send T_ACK in action A03 per the KNX spec.