### PR TITLE
compile Bus Isr with `-Os` to save flash space

### DIFF
--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -576,14 +576,14 @@ void Bus::sendNextTelegram()
  * Selecting the right state of SM Bus
  *
  */
-__attribute__((optimize("O3"))) void Bus::timerInterruptHandler()
+__attribute__((optimize("Os"))) void Bus::timerInterruptHandler()
 {
 	volatile bool timeout;
 	volatile int time;
 	unsigned int dt, tv, cv;
 
 #ifdef PIO_FOR_TEL_END_IND
-    digitalWrite(PIO_FOR_TEL_END_IND, 0);           // rest PIO
+    digitalWrite(PIO_FOR_TEL_END_IND, 0);           // restore handleTelegram() PIO
 #endif
 
 


### PR DESCRIPTION
Tests have shown that `-O3` does not really help to improve Isr's performance but increase its size by a lot (~1000 bytes)