### PR TITLE
Add cli option `timeout`

### DIFF
--- a/Bus-Updater/PC_updater_tool/source/README.md
+++ b/Bus-Updater/PC_updater_tool/source/README.md
@@ -58,6 +58,8 @@ Selfbus KNX-Firmware update tool options:
  -v,--version                               show tool/library version
     --delay <ms>                            delay telegrams during data transmission to reduce bus
                                             load, valid 0-500ms, default 0
+    --timeout                               Enable transport layer 4 connection-oriented 6s timeout.
+                                            Can be helpful with connection problems.
  -l,--logLevel <TRACE|DEBUG|INFO>           Logfile logging level [TRACE|DEBUG|INFO] (default DEBUG)
     --ERASEFLASH                            USE WITH CAUTION! Erases the complete flash memory
                                             including the physical KNX address and all settings of

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/CliOptions.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/CliOptions.java
@@ -77,6 +77,7 @@ public class CliOptions {
     private static final String OPT_LONG_UID = "uid";
 
     private static final String OPT_LONG_DELAY = "delay";
+    private static final String OPT_LONG_TIMEOUT = "timeout"; ///\todo delete after TL4 Style 3 implementation in sblib
 
     private static final String OPT_SHORT_NAT = "n";
     private static final String OPT_LONG_NAT = "nat";
@@ -143,6 +144,8 @@ public class CliOptions {
     private byte[] uid;
     private boolean full = false;
     private int delay = 0;
+
+    private boolean tl4Timeout = false; ///\todo delete after TL4 Style 3 implementation in sblib
     private boolean NO_FLASH = false;
     private Level logLevel = Level.DEBUG;
     private boolean eraseFullFlash = false;
@@ -173,6 +176,7 @@ public class CliOptions {
         Option version = new Option(OPT_SHORT_VERSION, OPT_LONG_VERSION, false, "show tool/library version");
         Option NO_FLASH = new Option(OPT_SHORT_NO_FLASH, OPT_LONG_NO_FLASH, false, "for debugging use only, disable flashing firmware!");
         Option eraseFlash = new Option(null, OPT_LONG_ERASEFLASH, false, "USE WITH CAUTION! Erases the complete flash memory including the physical KNX address and all settings of the device. Only the bootloader is not deleted.");
+        Option timeout = new Option(null, OPT_LONG_TIMEOUT, false, "Enable transport layer 4 connection-oriented 6000ms timeout. Can be helpful with connection problems.");
 
         Option dumpFlash = Option.builder(null).longOpt(OPT_LONG_DUMPFLASH)
                 .argName("start> <end")
@@ -328,6 +332,7 @@ public class CliOptions {
         cliOptions.addOptionGroup(grpHelper);
 
         cliOptions.addOption(delay);
+        cliOptions.addOption(timeout);
         cliOptions.addOption(logLevel);
         cliOptions.addOption(eraseFlash);
         cliOptions.addOption(dumpFlash);
@@ -466,6 +471,11 @@ public class CliOptions {
                 }
             }
             logger.debug("delay={}", delay);
+
+            if (cmdLine.hasOption(OPT_LONG_TIMEOUT)) {
+                tl4Timeout = true;
+            }
+            logger.debug("tl4Timeout={}", tl4Timeout);
 
             if (cmdLine.hasOption(OPT_SHORT_UID)) {
                uid =  uidToByteArray(cmdLine.getOptionValue(OPT_SHORT_UID));
@@ -655,6 +665,8 @@ public class CliOptions {
     public int delay() {
         return delay;
     }
+
+    public boolean tl4Timeout() { return tl4Timeout; }
 
     public boolean NO_FLASH() {
         return NO_FLASH;

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Mcu.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Mcu.java
@@ -20,6 +20,4 @@ public final class Mcu {
 
     /** Default restart time of the MCU in seconds */
     public static final int DEFAULT_RESTART_TIME_SECONDS = 6;
-    /** KNX transport layer 4 connection timeout */
-    public static final int TL4_CONNECTION_TIMEOUT_MS = 6300;
 }

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
@@ -292,6 +292,8 @@ public class Updater implements Runnable {
 
             DeviceManagement dm = new DeviceManagement(link, cliOptions.progDevice(), RESPONSE_TIMEOUT_SEC, cliOptions.priority());
 
+            dm.setTL4Timeout(cliOptions.tl4Timeout()); ///\todo delete after TL4 Style 3 implementation in sblib
+
             logger.info("KNX connection: {}\n", link);
 
             logger.info("Telegram priority: {}", cliOptions.priority());


### PR DESCRIPTION
The sblib implements the `Transport Layer 4 Style 1 Rationalised` which, together with calimero-core, can cause connection aborts ending in an infinite loop of `T_CONNECT/T_DISCONNECT`. The new cli option `--timeout` prevents this by utilizing the 6s timeout (defined in the transport layer) after a `T_DISCONNECT` to set the bootloader back to a defined state.