### PR TITLE
Improve detection and handling of spikes, and their consequences

### DIFF
--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -360,13 +360,14 @@ private:
 #define RX_STARTBIT_ERROR 1             //!< we detected high level few us after cap. event of start bit
 #define RX_STOPBIT_ERROR 2              //!< we received a cap event during stop bit
 #define RX_TIMING_ERROR 4               //!< received edge of bits is not in the timing window n*104-7 - n*104+33
-#define RX_TIMING_ERROR_SPIKE 8         //!< received edge of bit but low pulse is to short
-#define RX_PARITY_ERROR 16              //!< parity not valid
-#define RX_CHECKSUM_ERROR 32            //!< checksum not valid
-#define RX_LENGHT_ERROR 64              //!< received number of byte does not match length value of telegram
-#define RX_BUFFER_BUSY 128              //!< rx buffer still busy by higher layer process while a new telegram was received
-#define RX_INVALID_TELEGRAM_ERROR 256   //!< we received something but not a valid tel frame: to short,  to long, spike
-#define RX_PREAMBLE_ERROR 512		    //!< first char we received has invalid value in bit 0 and bit 1
+#define RX_TIMING_ERROR_SPIKE_IGNORED 8 //!< received edge of bit but low pulse is to short
+#define RX_TIMING_ERROR_SPIKE 16        //!< received edge of bit with incorrect timing
+#define RX_PARITY_ERROR 32              //!< parity not valid
+#define RX_CHECKSUM_ERROR 64            //!< checksum not valid
+#define RX_LENGHT_ERROR 128              //!< received number of byte does not match length value of telegram
+#define RX_BUFFER_BUSY 256              //!< rx buffer still busy by higher layer process while a new telegram was received
+#define RX_INVALID_TELEGRAM_ERROR 512   //!< we received something but not a valid tel frame: to short,  to long, spike
+#define RX_PREAMBLE_ERROR 1024		    //!< first char we received has invalid value in bit 0 and bit 1
 
 #define TX_OK 0                     //!< No error
 #define TX_STARTBIT_BUSY_ERROR 1	//!< bus is busy few us before we intended to send a start bit

--- a/sblib/inc/sblib/eib/bus.h
+++ b/sblib/inc/sblib/eib/bus.h
@@ -357,17 +357,15 @@ private:
 
 //define some error states
 #define RX_OK 0
-#define RX_STARTBIT_ERROR 1             //!< we detected high level few us after cap. event of start bit
-#define RX_STOPBIT_ERROR 2              //!< we received a cap event during stop bit
-#define RX_TIMING_ERROR 4               //!< received edge of bits is not in the timing window n*104-7 - n*104+33
-#define RX_TIMING_ERROR_SPIKE_IGNORED 8 //!< received edge of bit but low pulse is to short
-#define RX_TIMING_ERROR_SPIKE 16        //!< received edge of bit with incorrect timing
-#define RX_PARITY_ERROR 32              //!< parity not valid
-#define RX_CHECKSUM_ERROR 64            //!< checksum not valid
-#define RX_LENGHT_ERROR 128              //!< received number of byte does not match length value of telegram
-#define RX_BUFFER_BUSY 256              //!< rx buffer still busy by higher layer process while a new telegram was received
-#define RX_INVALID_TELEGRAM_ERROR 512   //!< we received something but not a valid tel frame: to short,  to long, spike
-#define RX_PREAMBLE_ERROR 1024		    //!< first char we received has invalid value in bit 0 and bit 1
+#define RX_STOPBIT_ERROR 1              //!< we received a cap event during stop bit
+#define RX_TIMING_ERROR 2               //!< received edge of bits is not in the timing window n*104-7 - n*104+33
+#define RX_TIMING_ERROR_SPIKE 4         //!< received edge of bit with incorrect timing
+#define RX_PARITY_ERROR 8               //!< parity not valid
+#define RX_CHECKSUM_ERROR 16            //!< checksum not valid
+#define RX_LENGHT_ERROR 32              //!< received number of byte does not match length value of telegram
+#define RX_BUFFER_BUSY 64               //!< rx buffer still busy by higher layer process while a new telegram was received
+#define RX_INVALID_TELEGRAM_ERROR 128   //!< we received something but not a valid tel frame: to short,  to long, spike
+#define RX_PREAMBLE_ERROR 256           //!< first char we received has invalid value in bit 0 and bit 1
 
 #define TX_OK 0                     //!< No error
 #define TX_STARTBIT_BUSY_ERROR 1	//!< bus is busy few us before we intended to send a start bit

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -726,7 +726,12 @@ __attribute__((optimize("Os"))) void Bus::timerInterruptHandler()
 		{
 			time = timer.capture(captureChannel); // we received an capt. event: new low bit
 			// read the bit again (about few us after cap event) if it is not at low level we received a spike - set error flag and continue
-			if (digitalRead(rxPin)) rx_error |= RX_TIMING_ERROR_SPIKE; // we set error flag and continue rx process
+			if (digitalRead(rxPin))
+			{
+				// we set error flag and continue rx process
+				rx_error |= RX_TIMING_ERROR_SPIKE_IGNORED;
+				break;
+			}
 		}
 
 		// find the bit position after last low bit and add high bits accordingly, window for the reception of falling edge of a bit is:

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -1095,7 +1095,14 @@ __attribute__((optimize("Os"))) void Bus::timerInterruptHandler()
 		//tb_h( SEND_WAIT_FOR_HIGH_BIT_END+200, timer.captureMode(captureChannel),  tb_in);
 		//tb_h( state+100, sendAck, tb_in);
 
-		if (timer.flag(captureChannel)){
+		if (timer.flag(captureChannel))
+		{
+			// If it was just a very short spike, ignore it and continue transmitting.
+			if (digitalRead(rxPin))
+			{
+				break;
+			}
+
 			if (( timer.capture(captureChannel) < timer.match(pwmChannel) - BIT_WAIT_TIME +30 ) &&  // add bit margin: early 7us, late 30us
 					(timer.capture(captureChannel) > BIT_WAIT_TIME - 7))  // subtract 7 margin for early bit
 			{

--- a/sblib/src/eib/bus.cpp
+++ b/sblib/src/eib/bus.cpp
@@ -745,7 +745,7 @@ __attribute__((optimize("Os"))) void Bus::timerInterruptHandler()
 		//tb_t( RECV_BITS_OF_BYTE, ttimer.value(), tb_in);
 
 		timeout = timer.flag(timeChannel); // timeout--> end of rx byte
-		if (timeout) time = BYTE_TIME_INCL_STOP; // BYTE_TIME = 11 bits
+		if (timeout) time = timer.match(timeChannel); // end of stop bit
 		else
 		{
 			time = timer.capture(captureChannel); // we received an capt. event: new low bit

--- a/test/sblib/src/protocol.cpp
+++ b/test/sblib/src/protocol.cpp
@@ -103,6 +103,7 @@ static void _handleBusSendingInterrupt(BcuDefault* currentBcu)
 
      if (currentBcu->bus->state == Bus::SEND_START_BIT)
      {
+        _LPC_TMR16B1.TC += 10;
         currentBcu->bus->state = Bus::SEND_END_OF_TX;
         currentBcu->bus->timerInterruptHandler();
         if (currentBcu->bus->state == Bus::SEND_WAIT_FOR_RX_ACK_WINDOW)  // device request an ACK -> so inject one


### PR DESCRIPTION
* RX pin must be low for at least 3µs to be regarded as 0 bit (this filters out short spikes)
* On collisions due to spikes, logging of end of stop bit was incorrect
* Collision detection only performed when falling edges are supposed to happen per the bus timing
* Received repeated telegrams must also be LL_ACKed, even if the first/previous repetition was processed correctly
* Sent repeated telegrams must always have the repeated indicator set