### PR TITLE
Add sblib version to `UPD_RESPONSE_BL_IDENTITY` response

### DIFF
--- a/Bus-Updater/.cproject
+++ b/Bus-Updater/.cproject
@@ -4,7 +4,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.debug.2082284562.1664299275">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.2082284562.1664299275" moduleId="org.eclipse.cdt.core.settings" name="Debug (LPC11XX)">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -152,7 +152,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.2048246081.1074517531.1756130074">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.2048246081.1074517531.1756130074" moduleId="org.eclipse.cdt.core.settings" name="Release (LPC11xx)">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -281,7 +281,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.2048246081.1074517531.1756130074.1038568057">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.2048246081.1074517531.1756130074.1038568057" moduleId="org.eclipse.cdt.core.settings" name="Release APROG (LPC11xx)">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -411,7 +411,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.debug.2082284562.1664299275.1313034378">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.2082284562.1664299275.1313034378" moduleId="org.eclipse.cdt.core.settings" name="Debug low level (LPC11XX)">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>

--- a/Bus-Updater/BootloaderLoader/.cproject
+++ b/Bus-Updater/BootloaderLoader/.cproject
@@ -4,7 +4,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.debug.29419348">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.29419348" moduleId="org.eclipse.cdt.core.settings" name="Debug">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -137,7 +137,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.189047520">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.189047520" moduleId="org.eclipse.cdt.core.settings" name="Release">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -265,7 +265,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.debug.29419348.296615997">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.debug.29419348.296615997" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x7000 Debug">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -402,7 +402,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.189047520.1083885240">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.189047520.1083885240" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -530,7 +530,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.189047520.847119930">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.189047520.847119930" moduleId="org.eclipse.cdt.core.settings" name="Release APROG">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -658,7 +658,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.189047520.847119930.1337538615">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.189047520.847119930.1337538615" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0x3000 Release APROG">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>
@@ -786,7 +786,7 @@
 		<cconfiguration id="com.crt.advproject.config.exe.release.189047520.1134010857">
 			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="com.crt.advproject.config.exe.release.189047520.1134010857" moduleId="org.eclipse.cdt.core.settings" name="Flashstart 0xA000 Release">
 				<macros>
-					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.10"/>
+					<stringMacro name="sw_version" type="VALUE_TEXT" value="1.11"/>
 				</macros>
 				<externalSettings/>
 				<extensions>

--- a/Bus-Updater/BootloaderLoader/src/app_main.cpp
+++ b/Bus-Updater/BootloaderLoader/src/app_main.cpp
@@ -19,9 +19,9 @@ extern const uint8_t incbin_bl_end[];
 
 #define BOOTLOADER_FLASH_STARTADDRESS ((uint8_t *) 0x0) //!< Flash start address of the bootloader
 constexpr uint8_t LOADERLOADER_MAJOR_VERSION = 1;       //!< Bootloader Loader major version @note change also in @ref APP_VERSION
-constexpr uint8_t LOADERLOADER_MINOR_VERSION = 10;      //!< Bootloader Loader minor Version @note change also in @ref APP_VERSION
+constexpr uint8_t LOADERLOADER_MINOR_VERSION = 11;      //!< Bootloader Loader minor Version @note change also in @ref APP_VERSION
 
-APP_VERSION("SBloader", "1", "10");
+APP_VERSION("SBloader", "1", "11");
 
 void setup()
 {

--- a/Bus-Updater/PC_updater_tool/source/README.md
+++ b/Bus-Updater/PC_updater_tool/source/README.md
@@ -1,4 +1,4 @@
-# Selfbus-Updater 1.10
+# Selfbus-Updater 1.11
 
 ## Requirements
 

--- a/Bus-Updater/PC_updater_tool/source/build.gradle
+++ b/Bus-Updater/PC_updater_tool/source/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.selfbus'
-version '1.10' ///\todo also change in README.md and ToolInfo.java (String version)
+version '1.11' ///\todo also change in README.md and ToolInfo.java (String version)
 
 sourceCompatibility = 11
 

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/DeviceManagement.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/DeviceManagement.java
@@ -159,13 +159,13 @@ public final class DeviceManagement {
         BootloaderIdentity bl = BootloaderIdentity.fromArray(Arrays.copyOfRange(result, DATA_POSITION, result.length));
         logger.info("  Device Bootloader: {}{}{}", ConColors.BRIGHT_YELLOW, bl, ConColors.RESET);
 
-        boolean versionsMatch = (bl.versionMajor() > ToolInfo.minMajorVersionBootloader()) ||
-                ((bl.versionMajor() == ToolInfo.minMajorVersionBootloader()) && (bl.versionMinor() >= ToolInfo.minMinorVersionBootloader()));
+        boolean versionsMatch = (bl.getVersionMajor() > ToolInfo.minMajorVersionBootloader()) ||
+                ((bl.getVersionMajor() == ToolInfo.minMajorVersionBootloader()) && (bl.getVersionMinor() >= ToolInfo.minMinorVersionBootloader()));
 
         if (!versionsMatch)
         {
             logger.error("{}Bootloader version {} is not compatible, please update Bootloader to version {} or higher{}",
-                    ConColors.RED, bl.version(), ToolInfo.minVersionBootloader(), ConColors.RESET);
+                    ConColors.RED, bl.getVersion(), ToolInfo.minVersionBootloader(), ConColors.RESET);
             throw new UpdaterException("Bootloader version not compatible!");
         }
         return bl;

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/ToolInfo.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/ToolInfo.java
@@ -12,7 +12,7 @@ import tuwien.auto.calimero.Settings;
 public final class ToolInfo
 {
     private static final long versionMajor = 1; ///\todo change also in README.md and build.gradle
-    private static final long versionMinor = 10;
+    private static final long versionMinor = 11;
 
     private static final long minMajorVersionBootloader = 1; ///\todo change also in README.md
     private static final long minMinorVersionBootloader = 0;
@@ -75,6 +75,6 @@ public final class ToolInfo
     public static String minVersionBootloader() {
         return new BootloaderIdentity(minMajorVersionBootloader(),
                                       minMinorVersionBootloader(),
-                                      0,0).version();
+                        0, 0, 0, 0).getVersion();
     }
 }

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/Updater.java
@@ -367,17 +367,17 @@ public class Updater implements Runnable {
             }
 
             // Check if FW image has correct offset for MCUs bootloader size
-            if (newFirmware.startAddress() < bootLoaderIdentity.applicationFirstAddress()) {
+            if (newFirmware.startAddress() < bootLoaderIdentity.getApplicationFirstAddress()) {
                 logger.error("{}  Error! The specified firmware image would overwrite parts of the bootloader. Check FW offset setting in the linker!{}", ConColors.BRIGHT_RED, ConColors.RESET);
-                logger.error("{}  Firmware needs to start at or beyond 0x{}{}", ConColors.BRIGHT_RED, String.format("%04X", bootLoaderIdentity.applicationFirstAddress()), ConColors.RESET);
+                logger.error("{}  Firmware needs to start at or beyond 0x{}{}", ConColors.BRIGHT_RED, String.format("%04X", bootLoaderIdentity.getApplicationFirstAddress()), ConColors.RESET);
                 throw new UpdaterException("Firmware offset not correct!");
             }
-            else if (newFirmware.startAddress() == bootLoaderIdentity.applicationFirstAddress()) {
+            else if (newFirmware.startAddress() == bootLoaderIdentity.getApplicationFirstAddress()) {
                 logger.info("  {}Firmware starts directly beyond bootloader.{}", ConColors.BRIGHT_GREEN, ConColors.RESET);
             }
             else {
                 logger.info("  {}Info: There are {} bytes of unused flash between bootloader and firmware.{}",
-                            ConColors.BRIGHT_YELLOW, newFirmware.startAddress() - bootLoaderIdentity.applicationFirstAddress(), ConColors.RESET);
+                            ConColors.BRIGHT_YELLOW, newFirmware.startAddress() - bootLoaderIdentity.getApplicationFirstAddress(), ConColors.RESET);
             }
 
             // Request current main firmware boot descriptor from device

--- a/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderIdentity.java
+++ b/Bus-Updater/PC_updater_tool/source/src/main/java/org/selfbus/updater/bootloader/BootloaderIdentity.java
@@ -9,10 +9,14 @@ import org.selfbus.updater.Utils;
 public class BootloaderIdentity {
     private final long versionMajor;
     private final long versionMinor;
+    private final long versionSBLibMajor;
+    private final long versionSBLibMinor;
     private final long features;
     private final long applicationFirstAddress;
 
-    public BootloaderIdentity(long versionMajor, long versionMinor, long features, long applicationFirstAddress) {
+    public BootloaderIdentity(long versionMajor, long versionMinor, long versionSBLibMajor, long versionSBLibMinor, long features, long applicationFirstAddress) {
+        this.versionSBLibMajor = versionSBLibMajor;
+        this.versionSBLibMinor = versionSBLibMinor;
         this.features = features;
         this.applicationFirstAddress = applicationFirstAddress;
         this.versionMajor = versionMajor;
@@ -22,37 +26,51 @@ public class BootloaderIdentity {
     public static BootloaderIdentity fromArray(byte[] parse) {
         long vMajor = parse[0] & 0xff;
         long vMinor = parse[1] & 0xff;
-        long features = Utils.streamToLong(parse, 2);
+        long features = Utils.streamToShort(parse, 2);
+        long versionSBLibMajor = parse[4] & 0xff;
+        long versionSBLibMinor= parse[5] & 0xff;
         long applicationFirstAddress = Utils.streamToLong(parse, 6);
-        return new BootloaderIdentity(vMajor, vMinor, features, applicationFirstAddress );
+        return new BootloaderIdentity(vMajor, vMinor, versionSBLibMajor, versionSBLibMinor, features, applicationFirstAddress );
     }
 
     public String toString() {
-        return String.format("Version: %s, Features: 0x%04X, App-start: 0x%04X",
-                              version(), features(), applicationFirstAddress());
+        return String.format("Version: %s, sbLib Version: %s, Features: 0x%04X, App-start: 0x%04X",
+                              getVersion(), getVersionSBLib(), getFeatures(), getApplicationFirstAddress());
     }
 
-    public long features()
+    public long getFeatures()
     {
         return features;
     }
 
-    public long applicationFirstAddress()
+    public long getApplicationFirstAddress()
     {
         return applicationFirstAddress;
     }
 
-    public long versionMajor()
+    public long getVersionMajor()
     {
         return versionMajor;
     }
 
-    public long versionMinor()
+    public long getVersionMinor()
     {
         return versionMinor;
     }
 
-    public String version() {
-        return String.format("%d.%02d", versionMajor(), versionMinor());
+    public long getVersionSBLibMajor() {
+        return versionSBLibMajor;
+    }
+
+    public long getVersionSBLibMinor() {
+        return versionSBLibMinor;
+    }
+
+    public String getVersion() {
+        return String.format("%d.%02d", getVersionMajor(), getVersionMinor());
+    }
+
+    public String getVersionSBLib() {
+        return String.format("%d.%02d", getVersionSBLibMajor(), getVersionSBLibMinor());
     }
 }

--- a/Bus-Updater/inc/version.h
+++ b/Bus-Updater/inc/version.h
@@ -25,7 +25,7 @@
 #include <stdint.h>
 
 constexpr uint8_t BOOTLOADER_MAJOR_VERSION = 1;  //!< Bootloader major version @note change also in BootloaderLoader's app_main.cpp
-constexpr uint8_t BOOTLOADER_MINOR_VERSION = 10; //!< Bootloader minor version @note change also in BootloaderLoader's app_main.cpp
+constexpr uint8_t BOOTLOADER_MINOR_VERSION = 11; //!< Bootloader minor version @note change also in BootloaderLoader's app_main.cpp
 
 constexpr uint8_t UPDATER_MIN_MAJOR_VERSION = 1; //!< minimum required major version of the Selfbus Updater we are talking to
 constexpr uint8_t UPDATER_MIN_MINOR_VERSION = 0; //!< minimum required minor version of the Selfbus Updater we are talking to

--- a/Bus-Updater/src/bootloader.cpp
+++ b/Bus-Updater/src/bootloader.cpp
@@ -30,6 +30,8 @@
 
 #ifdef DEBUG
 #   include <sblib/serial.h>
+#   include <sblib/version.h>
+#   include <sblib/bits.h>
 #   include "flash.h"
 #endif
 
@@ -111,10 +113,12 @@ BcuBase* setup()
     serial.print("Selfbus KNX Bootloader v", BOOTLOADER_MAJOR_VERSION);
     serial.print(".", BOOTLOADER_MINOR_VERSION, DEC, 2);
     serial.println(" DEBUG MODE :-)");
-    serial.print("Build: ");
+    serial.print("Build                       : ");
     serial.print(__DATE__);
     serial.print(" ");
     serial.println(__TIME__);
+    serial.print("Library                     : v", highByte((uint16_t)SBLIB_VERSION), HEX, 2);  // lib version is in hexadecimal
+    serial.println(".", lowByte(SBLIB_VERSION), HEX, 2);
     serial.println("Features                    : 0x", BL_FEATURES, HEX, 6);
     serial.print("Flash      (start,end,size) : 0x", flashFirstAddress());
     serial.print(" 0x", flashLastAddress());

--- a/Bus-Updater/src/update.cpp
+++ b/Bus-Updater/src/update.cpp
@@ -530,10 +530,14 @@ static bool updRequestBootloaderIdentity(uint8_t * data)
         return (true);
     }
 
-    uint32_t bootloaderFeatures = BL_FEATURES;
+    uint16_t bootloaderFeatures = BL_FEATURES;
+    uint8_t majorSBLibVersion = highByte((uint16_t)SBLIB_VERSION);
+    uint8_t minorSBLibVersion = lowByte(SBLIB_VERSION);
     uint8_t * appFirstAddress = applicationFirstAddress();
     const uint32_t dataSize = sizeof(BOOTLOADER_MAJOR_VERSION) +
                               sizeof(BOOTLOADER_MINOR_VERSION) +
+                              sizeof(majorSBLibVersion) +
+                              sizeof(minorSBLibVersion) +
                               sizeof(bootloaderFeatures) +
                               sizeof(appFirstAddress);
 
@@ -542,8 +546,12 @@ static bool updRequestBootloaderIdentity(uint8_t * data)
     offset += sizeof(BOOTLOADER_MAJOR_VERSION);
     retTelegram[offset] = BOOTLOADER_MINOR_VERSION;
     offset += sizeof(BOOTLOADER_MINOR_VERSION);
-    uInt32ToStream(retTelegram + offset, bootloaderFeatures);
+    uShort16ToStream(retTelegram + offset, bootloaderFeatures);
     offset += sizeof(bootloaderFeatures);
+    retTelegram[offset] = majorSBLibVersion;
+    offset += sizeof(majorSBLibVersion);
+    retTelegram[offset] = minorSBLibVersion;
+    offset += sizeof(minorSBLibVersion);
     ptrToStream(retTelegram + offset, appFirstAddress);
     d3(serial.print("BL v", BOOTLOADER_MAJOR_VERSION, DEC));
     d3(serial.print(".", BOOTLOADER_MINOR_VERSION, DEC, 2));


### PR DESCRIPTION
This PR enables the PC_Updater_Tool to retrieve and display the sbLibs version of a bus-updater/bootloader with the `UPD_REQUEST_BL_IDENTITY` command