### PR TITLE
Fixes #114 BLU doesn't always correctly erase its own `BootDescriptorBlock`

### DIFF
--- a/firmware_updater/bootloaderupdater/src/app_main.cpp
+++ b/firmware_updater/bootloaderupdater/src/app_main.cpp
@@ -28,7 +28,7 @@ extern const uint8_t incbin_bl_end[];
 ///\todo Create common header of constants shared between BL and BLU
 #define BOOTLOADER_FLASH_STARTADDRESS ((uint8_t *) 0x0) //!< Flash start address of the bootloader
 
-/** Size of the BootBlockDescriptor. Must match the BOOT_BLOCK_DESC_SIZE of the BL in the boot_descriptor_block.h */
+/** Size of the BootDescriptorBlock. Must match the BOOT_BLOCK_DESC_SIZE of the BL in the boot_descriptor_block.h */
 constexpr uint16_t BOOT_BLOCK_DESC_SIZE = 0x100; // same as FLASH_PAGE_SIZE of sblib/platform.h
 
 void setup()
@@ -104,7 +104,7 @@ int main()
         {
             // NXP bootloader uses an Int-Vect as a checksum to see if the application is valid.
             // If the value is not correct, then it does not start the application
-            // Vector table start always at base address, each entry is 4 byte
+            // Vector table starts always at base address, each entry is 4 bytes
             uint32_t checksum = 0;
             for (int j = 0; j < 7; j++) // Checksum is 2's complement of entries 0 through 6
             {

--- a/firmware_updater/bootloaderupdater/src/app_main.cpp
+++ b/firmware_updater/bootloaderupdater/src/app_main.cpp
@@ -70,47 +70,47 @@ int main()
         serial.println(" --> done");
     )
 
-	for (const uint8_t * i = incbin_bl_start; i < incbin_bl_end; i += FLASH_SECTOR_SIZE)
-	{
-	    __attribute__ ((aligned (FLASH_RAM_BUFFER_ALIGNMENT))) byte buf[FLASH_SECTOR_SIZE]; // Address of buf must be word aligned, see iapProgram(..) hint.
-		memset(buf, 0xFF, FLASH_SECTOR_SIZE);
-		unsigned int len = incbin_bl_end - i;
-		if (len > FLASH_SECTOR_SIZE)
-		{
-			len = FLASH_SECTOR_SIZE;
-		}
-		memcpy(buf, i, len);
+    for (const uint8_t * i = incbin_bl_start; i < incbin_bl_end; i += FLASH_SECTOR_SIZE)
+    {
+        __attribute__ ((aligned (FLASH_RAM_BUFFER_ALIGNMENT))) byte buf[FLASH_SECTOR_SIZE]; // Address of buf must be word aligned, see iapProgram(..) hint.
+        memset(buf, 0xFF, FLASH_SECTOR_SIZE);
+        unsigned int len = incbin_bl_end - i;
+        if (len > FLASH_SECTOR_SIZE)
+        {
+            len = FLASH_SECTOR_SIZE;
+        }
+        memcpy(buf, i, len);
 
-		uint8_t * flash = BOOTLOADER_FLASH_STARTADDRESS + (i - incbin_bl_start);
+        uint8_t * flash = BOOTLOADER_FLASH_STARTADDRESS + (i - incbin_bl_start);
 
-		if (flash == nullptr)
-		{
-	        // NXP bootloader uses an Int-Vect as a checksum to see if the application is valid.
-	        // If the value is not correct then it does not start the application
-		    // Vector table start always at base address, each entry is 4 byte
-		    uint32_t checksum = 0;
-			for (int j = 0; j < 7; j++) // Checksum is 2's complement of entries 0 through 6
-			{
-				checksum += *(int*)&buf[j*4];
-			}
-			checksum = -checksum;
-			*(int*)&buf[28] = checksum;
-		    d(
-		        serial.println("checksum: 0x", (int) checksum, HEX, 4);
-		    )
-		}
-	    d(
-	        serial.print("flashing 0x", flash);
-	    )
-		iapProgram(flash, buf, FLASH_SECTOR_SIZE);
-	    d(
-	        serial.println(" --> done");
-	    )
-	    digitalWrite(PIN_PROG, !digitalRead(PIN_PROG));
-	}
+        if (flash == nullptr)
+        {
+            // NXP bootloader uses an Int-Vect as a checksum to see if the application is valid.
+            // If the value is not correct then it does not start the application
+            // Vector table start always at base address, each entry is 4 byte
+            uint32_t checksum = 0;
+            for (int j = 0; j < 7; j++) // Checksum is 2's complement of entries 0 through 6
+            {
+                checksum += *(int*)&buf[j*4];
+            }
+            checksum = -checksum;
+            *(int*)&buf[28] = checksum;
+            d(
+                serial.println("checksum: 0x", (int) checksum, HEX, 4);
+            )
+        }
+        d(
+            serial.print("flashing 0x", flash);
+        )
+        iapProgram(flash, buf, FLASH_SECTOR_SIZE);
+        d(
+            serial.println(" --> done");
+        )
+        digitalWrite(PIN_PROG, !digitalRead(PIN_PROG));
+    }
     d(
         serial.println("RESET");
         serial.flush();
     )
-	NVIC_SystemReset();
+    NVIC_SystemReset();
 }

--- a/firmware_updater/bootloaderupdater/src/app_main.cpp
+++ b/firmware_updater/bootloaderupdater/src/app_main.cpp
@@ -2,6 +2,7 @@
 #include <sblib/io_pin_names.h>
 #include <sblib/digital_pin.h>
 #include <sblib/version.h>
+#include <cstdint>
 #include <cstring>
 
 #ifdef DEBUG
@@ -14,17 +15,21 @@
 #   define d(x)
 #endif
 
-extern const __attribute__((aligned(16))) uint8_t incbin_bl_start[];
-extern const uint8_t incbin_bl_end[];
-
-#define BOOTLOADER_FLASH_STARTADDRESS ((uint8_t *) 0x0) //!< Flash start address of the bootloader
-
-// Don't forget to change build-variable sw_version in .cproject file
+// Remember to change build-variable sw_version in .cproject file
 constexpr uint8_t BOOTLOADERUPDATER_MAJOR_VERSION = 1;  //!< BootloaderUpdater major version @note change also in @ref APP_VERSION
 constexpr uint8_t BOOTLOADERUPDATER_MINOR_VERSION = 20; //!< BootloaderUpdater minor Version @note change also in @ref APP_VERSION
 
-// changes of app version string must also be done in BootloaderUpdater.java of the Selfbus-Updater
+// changes of the app version string must also be done in BootloaderUpdater.java of the Selfbus-Updater
 APP_VERSION("SBblu   ", "1", "20");
+
+extern const __attribute__((aligned(16))) uint8_t incbin_bl_start[];
+extern const uint8_t incbin_bl_end[];
+
+///\todo Create common header of constants shared between BL and BLU
+#define BOOTLOADER_FLASH_STARTADDRESS ((uint8_t *) 0x0) //!< Flash start address of the bootloader
+
+/** Size of the BootBlockDescriptor. Must match the BOOT_BLOCK_DESC_SIZE of the BL in the boot_descriptor_block.h */
+constexpr uint16_t BOOT_BLOCK_DESC_SIZE = 0x100; // same as FLASH_PAGE_SIZE of sblib/platform.h
 
 void setup()
 {
@@ -64,8 +69,10 @@ int main()
     setup();
 
     const unsigned int newBlSize = (incbin_bl_end - incbin_bl_start);
+    const uint8_t* newBlEndAddress = BOOTLOADER_FLASH_STARTADDRESS + newBlSize - 1;
     const unsigned int newBlStartSector = iapSectorOfAddress(BOOTLOADER_FLASH_STARTADDRESS);
-    const unsigned int newBlEndSector = iapSectorOfAddress(BOOTLOADER_FLASH_STARTADDRESS + newBlSize - 1);
+    const unsigned int newBlEndSector = iapSectorOfAddress(newBlEndAddress);
+
     d(
         serial.println("newBlSize: 0x", newBlSize, HEX, 4);
         serial.print("Erasing Sectors: ", newBlStartSector);
@@ -96,7 +103,7 @@ int main()
         if (flash == nullptr)
         {
             // NXP bootloader uses an Int-Vect as a checksum to see if the application is valid.
-            // If the value is not correct then it does not start the application
+            // If the value is not correct, then it does not start the application
             // Vector table start always at base address, each entry is 4 byte
             uint32_t checksum = 0;
             for (int j = 0; j < 7; j++) // Checksum is 2's complement of entries 0 through 6
@@ -115,6 +122,19 @@ int main()
         }
         d(serial.println(" --> done");)
         digitalWrite(PIN_PROG, !digitalRead(PIN_PROG));
+    }
+
+    // Make sure that the current boot descriptor of the BLU is erased,
+    // otherwise the BL will restart the BLU in an infinite loop.
+    const uint32_t bootDescriptorBlockPage = iapPageOfAddress(newBlEndAddress + BOOT_BLOCK_DESC_SIZE);
+    d(serial.println("Erasing BootDescriptorPage: 0x", (unsigned int)bootDescriptorBlockPage, HEX);)
+    if (iapErasePageRange(bootDescriptorBlockPage, bootDescriptorBlockPage) != IAP_SUCCESS)
+    {
+        d(serial.println(" --> FAILED");)
+    }
+    else
+    {
+        d(serial.println(" --> done");)
     }
 
     SystemReset();

--- a/firmware_updater/bootloaderupdater/src/app_main.cpp
+++ b/firmware_updater/bootloaderupdater/src/app_main.cpp
@@ -15,7 +15,7 @@
 #   define d(x)
 #endif
 
-// Remember to change build-variable sw_version in .cproject file
+// Remember to change build-variable sw_version in the .cproject file
 constexpr uint8_t BOOTLOADERUPDATER_MAJOR_VERSION = 1;  //!< BootloaderUpdater major version @note change also in @ref APP_VERSION
 constexpr uint8_t BOOTLOADERUPDATER_MINOR_VERSION = 20; //!< BootloaderUpdater minor Version @note change also in @ref APP_VERSION
 
@@ -104,7 +104,7 @@ int main()
         {
             // NXP bootloader uses an Int-Vect as a checksum to see if the application is valid.
             // If the value is not correct, then it does not start the application
-            // Vector table starts always at base address, each entry is 4 bytes
+            // Vector table starts always at base address. Each entry is 4 bytes.
             uint32_t checksum = 0;
             for (int j = 0; j < 7; j++) // Checksum is 2's complement of entries 0 through 6
             {
@@ -125,7 +125,7 @@ int main()
     }
 
     // Make sure that the current boot descriptor of the BLU is erased,
-    // otherwise the BL will restart the BLU in an infinite loop.
+    // otherwise the BL will restart the BLU in an endless loop.
     const uint32_t bootDescriptorBlockPage = iapPageOfAddress(newBlEndAddress + BOOT_BLOCK_DESC_SIZE);
     d(serial.println("Erasing BootDescriptorPage: 0x", (unsigned int)bootDescriptorBlockPage, HEX);)
     if (iapErasePageRange(bootDescriptorBlockPage, bootDescriptorBlockPage) != IAP_SUCCESS)

--- a/firmware_updater/bootloaderupdater/src/app_main.cpp
+++ b/firmware_updater/bootloaderupdater/src/app_main.cpp
@@ -50,6 +50,15 @@ void setup()
     );
 }
 
+void SystemReset()
+{
+    d(
+        serial.println("RESET");
+        serial.flush();
+    )
+    NVIC_SystemReset();
+}
+
 int main()
 {
     setup();
@@ -63,7 +72,11 @@ int main()
         serial.print(" - ", newBlEndSector);
     )
 
-    iapEraseSectorRange(newBlStartSector, newBlEndSector);
+    if (iapEraseSectorRange(newBlStartSector, newBlEndSector) != IAP_SUCCESS)
+    {
+        d(serial.println(" --> FAILED");)
+        SystemReset();
+    }
 
     d(serial.println(" --> done");)
 
@@ -95,13 +108,14 @@ int main()
             d(serial.println("checksum: 0x", (int) checksum, HEX);)
         }
         d(serial.print("flashing 0x", flash);)
-        iapProgram(flash, buf, FLASH_SECTOR_SIZE);
+        if (iapProgram(flash, buf, FLASH_SECTOR_SIZE) != IAP_SUCCESS)
+        {
+            d(serial.println(" --> FAILED");)
+            SystemReset();
+        }
         d(serial.println(" --> done");)
         digitalWrite(PIN_PROG, !digitalRead(PIN_PROG));
     }
-    d(
-        serial.println("RESET");
-        serial.flush();
-    )
-    NVIC_SystemReset();
+
+    SystemReset();
 }

--- a/firmware_updater/bootloaderupdater/src/app_main.cpp
+++ b/firmware_updater/bootloaderupdater/src/app_main.cpp
@@ -38,15 +38,14 @@ void setup()
         {
             serial.begin(115200);
         }
-        serial.println("=========================================================");
+        serial.println();
         serial.print("Selfbus BootloaderUpdater v", BOOTLOADERUPDATER_MAJOR_VERSION);
-        serial.print(".", BOOTLOADERUPDATER_MINOR_VERSION, DEC, 3);
+        serial.print(".", BOOTLOADERUPDATER_MINOR_VERSION);
         serial.println(" DEBUG MODE :-)");
         serial.print("Build: ");
         serial.print(__DATE__);
         serial.print(" ");
         serial.println(__TIME__);
-        serial.println("---------------------------------------------------------");
         serial.flush();
     );
 }
@@ -61,14 +60,12 @@ int main()
     d(
         serial.println("newBlSize: 0x", newBlSize, HEX, 4);
         serial.print("Erasing Sectors: ", newBlStartSector);
-        serial.println(" - ", newBlEndSector);
+        serial.print(" - ", newBlEndSector);
     )
 
     iapEraseSectorRange(newBlStartSector, newBlEndSector);
 
-    d(
-        serial.println(" --> done");
-    )
+    d(serial.println(" --> done");)
 
     for (const uint8_t * i = incbin_bl_start; i < incbin_bl_end; i += FLASH_SECTOR_SIZE)
     {
@@ -95,17 +92,11 @@ int main()
             }
             checksum = -checksum;
             *(int*)&buf[28] = checksum;
-            d(
-                serial.println("checksum: 0x", (int) checksum, HEX, 4);
-            )
+            d(serial.println("checksum: 0x", (int) checksum, HEX);)
         }
-        d(
-            serial.print("flashing 0x", flash);
-        )
+        d(serial.print("flashing 0x", flash);)
         iapProgram(flash, buf, FLASH_SECTOR_SIZE);
-        d(
-            serial.println(" --> done");
-        )
+        d(serial.println(" --> done");)
         digitalWrite(PIN_PROG, !digitalRead(PIN_PROG));
     }
     d(


### PR DESCRIPTION
This PR closes #114 by ensuring that the `BootDescriptorBlock` page is always erased as the last step before resetting.